### PR TITLE
fix to prevent firewall restart on a bridgemode_event change

### DIFF
--- a/source/AdvSecurityDml/cosa_adv_security_internal.c
+++ b/source/AdvSecurityDml/cosa_adv_security_internal.c
@@ -2360,7 +2360,7 @@ void advsec_handle_sysevent_notification(char *event, char *val)
             ERR_CHK(rc);
             if((rc == EOK) && (ind == 0))
             {
-                CcspTraceInfo(("CcspAdvSecurity: Bridge mode unchanged, skipping action for value %s\n", val));
+                CcspTraceInfo(("CcspAdvSecurity: Bridge mode unchanged, no action needed %s\n", val));
                 return;
             }
 

--- a/source/AdvSecurityDml/cosa_adv_security_internal.c
+++ b/source/AdvSecurityDml/cosa_adv_security_internal.c
@@ -2339,6 +2339,7 @@ void advsec_handle_sysevent_notification(char *event, char *val)
     int ret = 0;
     errno_t rc = -1;
     int ind    = -1;
+    static char prevBridgeMode[8] = {0};
 
     if(!event || !val)
         return;
@@ -2349,6 +2350,23 @@ void advsec_handle_sysevent_notification(char *event, char *val)
     {
         if(type == SYSEVENT_BRIDGE_MODE_EVENT)
         {
+            if((val[0] == '\0') || (val[1] != '\0'))
+            {
+                CcspTraceWarning(("CcspAdvSecurity: Invalid bridge mode value '%s'\n", val));
+                return;
+            }
+
+            rc = strcmp_s(val, sizeof(prevBridgeMode), prevBridgeMode, &ind);
+            ERR_CHK(rc);
+            if((rc == EOK) && (ind == 0))
+            {
+                CcspTraceInfo(("CcspAdvSecurity: Bridge mode unchanged, skipping action for value %s\n", val));
+                return;
+            }
+
+            rc = strcpy_s(prevBridgeMode, sizeof(prevBridgeMode), val);
+            ERR_CHK(rc);
+
             if((val[0] == '0') && (val[1] == '\0'))
             {
                 CcspTraceWarning(("CcspAdvSecurity: Received Bridge Mode Off\n"));


### PR DESCRIPTION
RDKB-64489: [Field][DA]: Observed CujoAgent triggering firewall restart continously in 8.3p8s1

Reason for change: Bridgemode event is triggering a firewall restart, added fix to restart firewall only if the bridemode event value is different.
Test Procedure: set bridgemode to same value multiple times advsec shouldn't restart firewall.
Risks: Low
Signed-off-by: arunkumar_nagulapally@comcast.com