### PR TITLE
XF10-696: Correct MAC address format on agent side

### DIFF
--- a/source/AdvSecurityDml/cosa_adv_security_internal.c
+++ b/source/AdvSecurityDml/cosa_adv_security_internal.c
@@ -1161,9 +1161,10 @@ CosaSecurityInitialize
 #elif defined(PON_GATEWAY)
     // For PON gateway, always use HAL API
     char deviceMACStr[32] = {0};
-    if (platform_hal_GetBaseMacAddress(deviceMACStr) == 0)
+    rc = platform_hal_GetBaseMacAddress(deviceMACStr);
+    if ( rc == 0 && deviceMACStr[0] != '\0' )
     {
-        AnscMacToLower(deviceMac, deviceMACStr, sizeof(deviceMac));
+        strcpy_s(deviceMac, sizeof(deviceMac), deviceMACStr);
         CcspTraceInfo(("CcspAdvSecurity: deviceMac [%s]\n", deviceMac));
     }
     else


### PR DESCRIPTION
Reason for change:
Device details were not displayed correctly on the Cujo cloud. The root cause was that the MAC address was being sent in a non–colon‑separated format. This change ensures the MAC address is properly formatted before being sent from the agent to the cloud during connection.

Test Procedure:
- Load the updated image on the device.
- Verify that the agent successfully connects to the cloud.
- Confirm that device and client details are displayed correctly on the cloud portal.

Priority: P1
Risk: Low
Signed-off-by: Vysakh A V <vysakh.venugopal@sky.uk>