### PR TITLE
refactor: Analyse and refactor gtest testcases

### DIFF
--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp
@@ -18,14 +18,15 @@
 
 #include "CcspAdvSecurityMock.h"
 
-
+typedef void* ANSC_HANDLE;
+ANSC_HANDLE bus_handle = NULL;
 
 class CcspAdvSecurityDmlTestFixture : public CcspAdvSecurityTestBase {
 };
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_Enable) {
     BOOL resultBool;
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
+    PCOSA_DATAMODEL_AGENT pMyObject = (PCOSA_DATAMODEL_AGENT)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
     pMyObject->bEnable = TRUE;
     g_pAdvSecAgent = pMyObject;
 
@@ -33,6 +34,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_Enable
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = DeviceFingerPrint_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -40,12 +42,12 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_Enable
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    delete pMyObject;
+    free(pMyObject);
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_Disable) {
     BOOL resultBool;
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
+    PCOSA_DATAMODEL_AGENT pMyObject = (PCOSA_DATAMODEL_AGENT)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
     pMyObject->bEnable = FALSE;
     g_pAdvSecAgent = pMyObject;
 
@@ -53,6 +55,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_Disabl
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = DeviceFingerPrint_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -60,31 +63,32 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_Disabl
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    delete pMyObject;
+    free(pMyObject);
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_UnsupportedParam) {
     BOOL resultBool;
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
+    PCOSA_DATAMODEL_AGENT pMyObject = (PCOSA_DATAMODEL_AGENT)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
     g_pAdvSecAgent = pMyObject;
 
     const char* ParamName = "UnsupportedParam";
     int comparisonResult = 1;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = DeviceFingerPrint_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
 
     EXPECT_FALSE(result);
 
-    delete pMyObject;
+    free(pMyObject);
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamBoolValue_Enable) {
 
     const char *DeviceFingerPrintEnabled = "Advsecurity_DeviceFingerPrint";
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
+    PCOSA_DATAMODEL_AGENT pMyObject = (PCOSA_DATAMODEL_AGENT)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
     pMyObject->bEnable = FALSE;
     g_pAdvSecAgent = pMyObject;
 
@@ -93,15 +97,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamBoolValue_Enable
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enable &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecInit());
@@ -111,12 +120,12 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamBoolValue_Enable
     EXPECT_TRUE(result);
     EXPECT_TRUE(pMyObject->bEnable);
 
-    delete pMyObject;
+    free(pMyObject);
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamBoolValue_Disable) {
     const char *DeviceFingerPrintEnabled = "Advsecurity_DeviceFingerPrint";
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
+    PCOSA_DATAMODEL_AGENT pMyObject = (PCOSA_DATAMODEL_AGENT)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
     pMyObject->bEnable = TRUE;
     g_pAdvSecAgent = pMyObject;
 
@@ -125,15 +134,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamBoolValue_Disabl
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disable &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecDeInit());
@@ -143,12 +157,12 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamBoolValue_Disabl
     EXPECT_TRUE(result);
     EXPECT_FALSE(pMyObject->bEnable);
 
-    delete pMyObject;
+    free(pMyObject);
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamUlongValue_LoggingPeriod) {
     ULONG resultUlong;
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
+    PCOSA_DATAMODEL_AGENT pMyObject = (PCOSA_DATAMODEL_AGENT)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
     pMyObject->ulLoggingPeriod = 100;
     g_pAdvSecAgent = pMyObject;
 
@@ -156,6 +170,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamUlongValue_Loggi
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("LoggingPeriod"), strlen("LoggingPeriod"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = DeviceFingerPrint_GetParamUlongValue(NULL, (char*)ParamName, &resultUlong);
@@ -163,11 +178,11 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamUlongValue_Loggi
     EXPECT_TRUE(result);
     EXPECT_EQ(100, resultUlong);
 
-    delete pMyObject;
+    free(pMyObject);
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamUlongValue_LoggingPeriod) {
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
+    PCOSA_DATAMODEL_AGENT pMyObject = (PCOSA_DATAMODEL_AGENT)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
     pMyObject->ulLoggingPeriod = 100;
     g_pAdvSecAgent = pMyObject;
     const char *DeviceFingerPrintLogginPeriod = "Advsecurity_LoggingPeriod";
@@ -177,13 +192,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamUlongValue_Loggi
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("LoggingPeriod"), strlen("LoggingPeriod"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintLogginPeriod), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSetLoggingPeriod(bValue));
@@ -193,7 +212,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamUlongValue_Loggi
     EXPECT_TRUE(result);
     EXPECT_EQ(200, pMyObject->ulLoggingPeriod);
 
-    delete pMyObject;
+    free(pMyObject);
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamStringValue_EndpointURL) {
@@ -205,20 +224,25 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamStringValue_Endp
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("EndpointURL"), strlen("EndpointURL"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_get(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_safecLibMock, _strcpy_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecGetCustomURL(pValue, &pUlSize));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_get(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_safecLibMock, _strcpy_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     returnStatus = DeviceFingerPrint_GetParamStringValue(NULL, (char*)ParamName, pValue, &pUlSize);
@@ -235,11 +259,14 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamStringValue_Endp
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("EndpointURL"), strlen("EndpointURL"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCustomEndpointURL), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSetCustomURL(pString));
@@ -258,20 +285,25 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SetParamStringValue_Success) {
 
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Data"), strlen("Data"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_base64Mock, b64_get_decoded_buffer_size(strlen(pString)))
+        .Times(1)
         .WillOnce(Return(128));
 
     EXPECT_CALL(*g_base64Mock, b64_decode(reinterpret_cast<const uint8_t*>(pString), strlen(pString), testing::_))
+        .Times(1)
         .WillOnce(Return(64));
 
     msgpack_unpack_return unpack_ret = MSGPACK_UNPACK_SUCCESS;
     EXPECT_CALL(*g_msgpackMock, msgpack_zone_init(testing::_, 2048))
         .Times(1);
     EXPECT_CALL(*g_msgpackMock, msgpack_unpack(testing::_, 64, testing::_, testing::_, testing::_))
+        .Times(1)
         .WillOnce(Return(unpack_ret));
     EXPECT_CALL(*g_msgpackMock, msgpack_unpack_next(testing::_, testing::_, testing::_, testing::_))
+        .Times(1)
         .WillOnce(Return(unpack_ret));
     EXPECT_CALL(*g_msgpackMock, msgpack_object_print(testing::_, testing::_))
         .Times(1);
@@ -308,6 +340,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Enable) {
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = SafeBrowsing_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -336,6 +369,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Disable) {
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = SafeBrowsing_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -368,15 +402,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Enable) {
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -start sb null &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -432,15 +471,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Disable) {
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stop sb null &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -489,6 +533,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamUlongValue_LookupTime
     g_pAdvSecAgent->pAdvSec->pSafeBrows->ulLookupTimeout = 100;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("LookupTimeout"), strlen("LookupTimeout"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = SafeBrowsing_GetParamUlongValue(NULL, (char*)ParamName, &resultUlong);
@@ -518,13 +563,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamUlongValue_LookupTime
     g_pAdvSecAgent->pAdvSec->pSafeBrows->ulLookupTimeout = 100;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("LookupTimeout"), strlen("LookupTimeout"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBLookupTimeout), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSetLookupTimeout(bValue));
@@ -577,6 +626,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Enable) {
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = Softflowd_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -605,6 +655,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Disable) {
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = Softflowd_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -638,15 +689,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Enable) {
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySFEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -start null sf &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -703,15 +759,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Disable) {
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySFEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stop null sf &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -781,6 +842,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = AdvancedParentalControl_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -806,6 +868,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = AdvancedParentalControl_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -836,15 +899,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startAdvPC &"), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -895,15 +963,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopAdvPC &"), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -972,6 +1045,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Enable
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = PrivacyProtection_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -998,6 +1072,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Disabl
     g_pAdvSecAgent->pPrivProt->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = PrivacyProtection_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1027,15 +1102,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Enable
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityPPEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startPrivProt &"), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1086,15 +1166,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Disabl
     g_pAdvSecAgent->pPrivProt->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
+        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityPPEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopPrivProt &"), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1228,10 +1313,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MemoryLi
     g_pAdvSecAgent->pRabid->uMemoryLimit = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityRabidMemoryLimit), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaRabidSetMemoryLimit(NULL, bValue));
@@ -1260,10 +1348,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MacCache
     g_pAdvSecAgent->pRabid->uMacCacheSize = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityRabidMacCacheSize), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaRabidSetMacCacheSize(NULL, bValue));
@@ -1292,10 +1383,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_DNSCache
     g_pAdvSecAgent->pRabid->uDNSCacheSize = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityRabidDNSCacheSize), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaRabidSetDNSCacheSize(NULL, bValue));
@@ -1369,12 +1463,16 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolVa
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCRFCEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startAdvPC &"), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1425,12 +1523,16 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolVa
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCRFCEnabled), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopAdvPC &"), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1605,13 +1707,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolVa
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityDFICMPv6Enable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableICMP6 &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvDFIcmpv6Init(NULL));
@@ -1640,13 +1746,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolVa
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityDFICMPv6Enable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableICMP6 &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvDFIcmpv6DeInit(NULL));
@@ -1717,13 +1827,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValu
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityWSDisEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableWSDiscovery &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaWSDisInit(NULL));
@@ -1752,13 +1866,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValu
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityWSDisEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableWSDiscovery &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaWSDisDeInit(NULL));
@@ -1829,13 +1947,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityOTMEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableOTM &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecOTMInit(NULL));
@@ -1863,13 +1985,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityOTMEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableOTM &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecOTMDeInit(NULL));
@@ -1940,13 +2066,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_SetParamBoolValue_Ena
     g_pAdvSecAgent->pRaptr_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityRaptrEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableRaptr &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecAgentRaptrInit(NULL));
@@ -2043,13 +2173,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_SetParamBoolV
     g_pAdvSecAgent->pAdvWifiDataCollection_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityUserSpaceEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableUS &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecUserSpaceInit(NULL));
@@ -2083,13 +2217,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_SetParamBoolV
     g_pAdvSecAgent->pAdvWifiDataCollection_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityUserSpaceEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableUS &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecUserSpaceDeInit(NULL));
@@ -2162,13 +2300,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Enable) 
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAgentEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableAGT &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecAgentInit(NULL));
@@ -2197,13 +2339,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Disable)
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAgentEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableAGT &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecAgentDeInit(NULL));
@@ -2277,13 +2423,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_E
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySafeBrowsingEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableSBRule &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSafeBrowsingInit(NULL));
@@ -2316,13 +2466,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_D
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySafeBrowsingEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableSBRule &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSafeBrowsingDeInit(NULL));
@@ -2397,13 +2551,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBool
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTelemetryWiFiFPEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCTW &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTelemetryWiFiFPInit(NULL));
@@ -2436,13 +2594,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBool
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTelemetryWiFiFPEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCTW &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTelemetryWiFiFPDeInit(NULL));
@@ -2513,13 +2675,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBool
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTracerEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCT &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTracerInit(NULL));
@@ -2548,13 +2714,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBool
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTracerEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCT &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTracerDeInit(NULL));
@@ -2624,13 +2794,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamB
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTelemetryEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCTD &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTelemetryInit(NULL));
@@ -2659,13 +2833,17 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamB
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTelemetryEnable), _))
+        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCTD &"), _))
+        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTelemetryDeInit(NULL));

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp
@@ -18,68 +18,12 @@
 
 #include "CcspAdvSecurityMock.h"
 
-typedef void* ANSC_HANDLE;
-ANSC_HANDLE bus_handle = NULL;
 
 
-class CcspAdvSecurityDmlTestFixture : public ::testing::Test {
-protected:
-    void SetUp() override {
-        g_syscfgMock = new SyscfgMock();
-        g_securewrapperMock = new SecureWrapperMock();
-        g_msgpackMock = new msgpackMock();
-        g_usertimeMock = new UserTimeMock();
-        g_safecLibMock = new SafecLibMock();
-        g_anscMemoryMock = new AnscMemoryMock();
-        g_baseapiMock = new BaseAPIMock();
-        g_traceMock = new TraceMock();
-        g_base64Mock = new base64Mock();
-        g_rbusMock = new rbusMock();
-        g_cmHALMock = new CmHalMock();
-        g_platformHALMock = new PlatformHalMock();
-        g_cjsonMock = new cjsonMock();
-        g_syseventMock = new SyseventMock();
-        g_webconfigFwMock = new webconfigFwMock();
-        g_anscWrapperApiMock = new AnscWrapperApiMock();
-    }
-
-    void TearDown() override {
-        delete g_syscfgMock;
-        delete g_securewrapperMock;
-        delete g_msgpackMock;
-        delete g_usertimeMock;
-        delete g_safecLibMock;
-        delete g_anscMemoryMock;
-        delete g_baseapiMock;
-        delete g_traceMock;
-        delete g_base64Mock;
-        delete g_rbusMock;
-        delete g_cmHALMock;
-        delete g_platformHALMock;
-        delete g_cjsonMock;
-        delete g_syseventMock;
-        delete g_webconfigFwMock;
-        delete g_anscWrapperApiMock;
-        g_syscfgMock = nullptr;
-        g_securewrapperMock = nullptr;
-        g_msgpackMock = nullptr;
-        g_usertimeMock = nullptr;
-        g_safecLibMock = nullptr;
-        g_anscMemoryMock = nullptr;
-        g_baseapiMock = nullptr;
-        g_traceMock = nullptr;
-        g_base64Mock = nullptr;
-        g_rbusMock = nullptr;
-        g_cmHALMock = nullptr;
-        g_platformHALMock = nullptr;
-        g_cjsonMock = nullptr;
-        g_syseventMock = nullptr;
-        g_webconfigFwMock = nullptr;
-        g_anscWrapperApiMock = nullptr;
-    }
+class CcspAdvSecurityDmlTestFixture : public CcspAdvSecurityTestBase {
 };
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_Enable) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_Enable) {
     BOOL resultBool;
     PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
     pMyObject->bEnable = TRUE;
@@ -89,7 +33,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_E
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = DeviceFingerPrint_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -100,7 +43,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_E
     delete pMyObject;
 }
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_Disable) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_Disable) {
     BOOL resultBool;
     PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
     pMyObject->bEnable = FALSE;
@@ -110,7 +53,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_D
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = DeviceFingerPrint_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -121,7 +63,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_D
     delete pMyObject;
 }
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_UnsupportedParam) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamBoolValue_UnsupportedParam) {
     BOOL resultBool;
     PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
     g_pAdvSecAgent = pMyObject;
@@ -130,7 +72,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_U
     int comparisonResult = 1;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = DeviceFingerPrint_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -140,7 +81,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_U
     delete pMyObject;
 }
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_Enable) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamBoolValue_Enable) {
 
     const char *DeviceFingerPrintEnabled = "Advsecurity_DeviceFingerPrint";
     PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
@@ -152,20 +93,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_E
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enable &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecInit());
@@ -178,7 +114,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_E
     delete pMyObject;
 }
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_Disable) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamBoolValue_Disable) {
     const char *DeviceFingerPrintEnabled = "Advsecurity_DeviceFingerPrint";
     PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
     pMyObject->bEnable = TRUE;
@@ -189,20 +125,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_D
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disable &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecDeInit());
@@ -215,7 +146,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_D
     delete pMyObject;
 }
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamUlongValue_LoggingPeriod) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamUlongValue_LoggingPeriod) {
     ULONG resultUlong;
     PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
     pMyObject->ulLoggingPeriod = 100;
@@ -225,7 +156,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamUlongValue_
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("LoggingPeriod"), strlen("LoggingPeriod"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = DeviceFingerPrint_GetParamUlongValue(NULL, (char*)ParamName, &resultUlong);
@@ -236,7 +166,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamUlongValue_
     delete pMyObject;
 }
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamUlongValue_LoggingPeriod) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamUlongValue_LoggingPeriod) {
     PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
     pMyObject->ulLoggingPeriod = 100;
     g_pAdvSecAgent = pMyObject;
@@ -247,17 +177,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamUlongValue_
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("LoggingPeriod"), strlen("LoggingPeriod"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintLogginPeriod), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSetLoggingPeriod(bValue));
@@ -270,7 +196,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamUlongValue_
     delete pMyObject;
 }
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamStringValue_EndpointURL) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_GetParamStringValue_EndpointURL) {
     char pValue[256] = {0};
     ULONG pUlSize = 256;
     ANSC_STATUS returnStatus = ANSC_STATUS_SUCCESS;
@@ -279,25 +205,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamStringValue
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("EndpointURL"), strlen("EndpointURL"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_get(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_safecLibMock, _strcpy_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecGetCustomURL(pValue, &pUlSize));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_get(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_safecLibMock, _strcpy_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     returnStatus = DeviceFingerPrint_GetParamStringValue(NULL, (char*)ParamName, pValue, &pUlSize);
@@ -305,7 +226,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamStringValue
     EXPECT_EQ(ANSC_STATUS_SUCCESS, returnStatus);
 }
 
-TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamStringValue_EndpointURL) {
+TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrint_SetParamStringValue_EndpointURL) {
     char pString[256] = "\0";
     const char *AdvSecCustomEndpointURL = "Advsecurity_CustomEndpointURL";
     ANSC_STATUS returnStatus = ANSC_STATUS_SUCCESS;
@@ -314,14 +235,11 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamStringValue
     int comparisonResult = 0;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("EndpointURL"), strlen("EndpointURL"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCustomEndpointURL), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSetCustomURL(pString));
@@ -340,25 +258,20 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SetParamStringValue_Success) {
 
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Data"), strlen("Data"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_base64Mock, b64_get_decoded_buffer_size(strlen(pString)))
-        .Times(1)
         .WillOnce(Return(128));
 
     EXPECT_CALL(*g_base64Mock, b64_decode(reinterpret_cast<const uint8_t*>(pString), strlen(pString), testing::_))
-        .Times(1)
         .WillOnce(Return(64));
 
     msgpack_unpack_return unpack_ret = MSGPACK_UNPACK_SUCCESS;
     EXPECT_CALL(*g_msgpackMock, msgpack_zone_init(testing::_, 2048))
         .Times(1);
     EXPECT_CALL(*g_msgpackMock, msgpack_unpack(testing::_, 64, testing::_, testing::_, testing::_))
-        .Times(1)
         .WillOnce(Return(unpack_ret));
     EXPECT_CALL(*g_msgpackMock, msgpack_unpack_next(testing::_, testing::_, testing::_, testing::_))
-        .Times(1)
         .WillOnce(Return(unpack_ret));
     EXPECT_CALL(*g_msgpackMock, msgpack_object_print(testing::_, testing::_))
         .Times(1);
@@ -395,7 +308,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Enable) {
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = SafeBrowsing_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -424,7 +336,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Disable) {
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = SafeBrowsing_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -457,20 +368,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Enable) {
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -start sb null &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -526,20 +432,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Disable) {
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stop sb null &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -588,7 +489,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamUlongValue_LookupTime
     g_pAdvSecAgent->pAdvSec->pSafeBrows->ulLookupTimeout = 100;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("LookupTimeout"), strlen("LookupTimeout"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = SafeBrowsing_GetParamUlongValue(NULL, (char*)ParamName, &resultUlong);
@@ -618,17 +518,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamUlongValue_LookupTime
     g_pAdvSecAgent->pAdvSec->pSafeBrows->ulLookupTimeout = 100;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("LookupTimeout"), strlen("LookupTimeout"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBLookupTimeout), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSetLookupTimeout(bValue));
@@ -681,7 +577,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Enable) {
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = Softflowd_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -710,7 +605,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Disable) {
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = Softflowd_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -744,20 +638,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Enable) {
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySFEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -start null sf &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -814,20 +703,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Disable) {
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySFEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stop null sf &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -897,7 +781,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = AdvancedParentalControl_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -923,7 +806,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = AdvancedParentalControl_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -954,20 +836,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1018,20 +895,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1100,7 +972,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Enable
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = PrivacyProtection_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1127,7 +998,6 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Disabl
     g_pAdvSecAgent->pPrivProt->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     BOOL result = PrivacyProtection_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1157,20 +1027,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Enable
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityPPEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startPrivProt &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1221,20 +1086,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Disabl
     g_pAdvSecAgent->pPrivProt->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityPPEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopPrivProt &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1368,13 +1228,10 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MemoryLi
     g_pAdvSecAgent->pRabid->uMemoryLimit = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityRabidMemoryLimit), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaRabidSetMemoryLimit(NULL, bValue));
@@ -1403,13 +1260,10 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MacCache
     g_pAdvSecAgent->pRabid->uMacCacheSize = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityRabidMacCacheSize), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaRabidSetMacCacheSize(NULL, bValue));
@@ -1438,13 +1292,10 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_DNSCache
     g_pAdvSecAgent->pRabid->uDNSCacheSize = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityRabidDNSCacheSize), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaRabidSetDNSCacheSize(NULL, bValue));
@@ -1518,16 +1369,12 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolVa
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCRFCEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1578,16 +1425,12 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolVa
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCRFCEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1762,17 +1605,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolVa
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityDFICMPv6Enable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableICMP6 &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvDFIcmpv6Init(NULL));
@@ -1801,17 +1640,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolVa
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityDFICMPv6Enable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableICMP6 &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvDFIcmpv6DeInit(NULL));
@@ -1882,17 +1717,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValu
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityWSDisEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableWSDiscovery &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaWSDisInit(NULL));
@@ -1921,17 +1752,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValu
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityWSDisEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableWSDiscovery &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaWSDisDeInit(NULL));
@@ -2002,17 +1829,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityOTMEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableOTM &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecOTMInit(NULL));
@@ -2040,17 +1863,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityOTMEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableOTM &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecOTMDeInit(NULL));
@@ -2121,17 +1940,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_SetParamBoolValue_Ena
     g_pAdvSecAgent->pRaptr_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityRaptrEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableRaptr &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecAgentRaptrInit(NULL));
@@ -2228,17 +2043,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_SetParamBoolV
     g_pAdvSecAgent->pAdvWifiDataCollection_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityUserSpaceEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableUS &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecUserSpaceInit(NULL));
@@ -2272,17 +2083,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_SetParamBoolV
     g_pAdvSecAgent->pAdvWifiDataCollection_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityUserSpaceEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableUS &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecUserSpaceDeInit(NULL));
@@ -2355,17 +2162,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Enable) 
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAgentEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableAGT &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecAgentInit(NULL));
@@ -2394,17 +2197,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Disable)
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAgentEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableAGT &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecAgentDeInit(NULL));
@@ -2478,17 +2277,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_E
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySafeBrowsingEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableSBRule &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSafeBrowsingInit(NULL));
@@ -2521,17 +2316,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_D
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySafeBrowsingEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableSBRule &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecSafeBrowsingDeInit(NULL));
@@ -2606,17 +2397,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBool
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTelemetryWiFiFPEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCTW &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTelemetryWiFiFPInit(NULL));
@@ -2649,17 +2436,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBool
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTelemetryWiFiFPEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCTW &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTelemetryWiFiFPDeInit(NULL));
@@ -2730,17 +2513,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBool
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTracerEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCT &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTracerInit(NULL));
@@ -2769,17 +2548,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBool
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTracerEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCT &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTracerDeInit(NULL));
@@ -2849,17 +2624,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamB
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTelemetryEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCTD &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTelemetryInit(NULL));
@@ -2888,17 +2659,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamB
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityCujoTelemetryEnable), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCTD &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecCujoTelemetryDeInit(NULL));

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityInternalTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityInternalTest.cpp
@@ -18,62 +18,7 @@
 
 #include "CcspAdvSecurityMock.h"
 
-class CcspAdvSecurityInternalTestFixture : public ::testing::Test {
-protected:
-    void SetUp() override {
-
-       g_syscfgMock = new SyscfgMock();
-        g_securewrapperMock = new SecureWrapperMock();
-        g_msgpackMock = new msgpackMock();
-        g_usertimeMock = new UserTimeMock();
-        g_safecLibMock = new SafecLibMock();
-        g_anscMemoryMock = new AnscMemoryMock();
-        g_baseapiMock = new BaseAPIMock();
-        g_traceMock = new TraceMock();
-        g_base64Mock = new base64Mock();
-        g_rbusMock = new rbusMock();
-        g_cmHALMock = new CmHalMock();
-        g_platformHALMock = new PlatformHalMock();
-        g_cjsonMock = new cjsonMock();
-        g_syseventMock = new SyseventMock();
-        g_webconfigFwMock = new webconfigFwMock();
-        g_anscWrapperApiMock = new AnscWrapperApiMock();
-    }
-
-    void TearDown() override {
-        delete g_syscfgMock;
-        delete g_securewrapperMock;
-        delete g_msgpackMock;
-        delete g_usertimeMock;
-        delete g_safecLibMock;
-        delete g_anscMemoryMock;
-        delete g_baseapiMock;
-        delete g_traceMock;
-        delete g_base64Mock;
-        delete g_rbusMock;
-        delete g_cmHALMock;
-        delete g_platformHALMock;
-        delete g_cjsonMock;
-        delete g_syseventMock;
-        delete g_webconfigFwMock;
-        delete g_anscWrapperApiMock;
-        g_syscfgMock = nullptr;
-        g_securewrapperMock = nullptr;
-        g_msgpackMock = nullptr;
-        g_usertimeMock = nullptr;
-        g_safecLibMock = nullptr;
-        g_anscMemoryMock = nullptr;
-        g_baseapiMock = nullptr;
-        g_traceMock = nullptr;
-        g_base64Mock = nullptr;
-        g_rbusMock = nullptr;
-        g_cmHALMock = nullptr;
-        g_platformHALMock = nullptr;
-        g_cjsonMock = nullptr;
-        g_syseventMock = nullptr;
-        g_webconfigFwMock = nullptr;
-        g_anscWrapperApiMock = nullptr;
-    }
+class CcspAdvSecurityInternalTestFixture : public CcspAdvSecurityTestBase {
 };
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb) {
@@ -94,16 +39,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb) {
     g_pAdvSecAgent->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -start sb null &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r"))) {
@@ -148,16 +89,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sf) {
     g_pAdvSecAgent->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySFEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -start null sf &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r"))) {
@@ -209,16 +146,13 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb_sf) {
         .Times(2)
         .WillRepeatedly(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySFEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
         .Times(2)
         .WillRepeatedly(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -start sb sf &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -268,16 +202,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sb) {
     g_pAdvSecAgent->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stop sb null &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -325,16 +255,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sf) {
     g_pAdvSecAgent->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySFEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stop null sf &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecStopFeatures(type);
@@ -369,16 +295,13 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sb_sf) {
         .Times(2)
         .WillRepeatedly(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySBEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecuritySFEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
         .Times(2)
         .WillRepeatedly(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stop sb sf &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecStopFeatures(type);
@@ -404,16 +327,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, Cosa_AdvSec_Agent_Raptr_Init) {
     g_pAdvSecAgent->pRaptr_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(RaptrEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableRaptr &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecAgentRaptrInit(g_pAdvSecAgent->pRaptr_RFC);
@@ -436,16 +355,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, Cosa_AdvSec_Agent_Raptr_DeInit) {
     g_pAdvSecAgent->pRaptr_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(RaptrEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableRaptr &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecAgentRaptrDeInit(g_pAdvSecAgent->pRaptr_RFC);
@@ -472,16 +387,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_start_privacy_protection) {
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(PrivacyProtectionEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startPrivProt &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r"))) {
@@ -523,16 +434,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_stop_privacy_protection) {
     g_pAdvSecAgent->pPrivProt->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(PrivacyProtectionEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopPrivProt &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -573,16 +480,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecInit_Success)
     g_pAdvSecAgent->bEnable = TRUE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enable &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
 
@@ -602,16 +505,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecDeInit_Success)
     g_pAdvSecAgent->bEnable = FALSE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disable &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecDeInit();
@@ -636,16 +535,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaStartAdvParentalControl_Success)
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvParentalControl), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -692,16 +587,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaStopAdvParentalControl_Success)
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvParentalControl), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -770,7 +661,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_fingerpr
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enable &"),_))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(_, _))
         .Times(5)
@@ -851,7 +741,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_fingerpr
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disable &"),_))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(_, _))
         .Times(5)
@@ -932,7 +821,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_configur
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -configure_features &"),_))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(_, _))
         .Times(4)
@@ -997,13 +885,10 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSetLoggingPeriod)
     ULONG value = ADVSEC_DEFAULT_LOG_TIMEOUT;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintLogginPeriod), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecSetLoggingPeriod(value);
@@ -1034,16 +919,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSetLogLevel)
     ULONG value = 2;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintLogLevel), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -agentloglevel 2 &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecSetLogLevel(value);
@@ -1096,16 +977,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSetLookupTimeout)
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityLookupTimeout), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -start sb null &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecSetLookupTimeout(value);
@@ -1125,10 +1002,8 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSetCustomURL)
     char pString[] = "https://www.google.com";
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCustomEndpointURL), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecSetCustomURL(pString);
@@ -1143,7 +1018,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecGetCustomURL)
     ULONG ulSize = 20;
 
     EXPECT_CALL(*g_safecLibMock, _strcpy_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_get(_, StrEq(AdvSecCustomEndpointURL), _, _))
         .WillOnce(DoAll(
@@ -1169,13 +1043,10 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaRabidSetMemoryLimit)
     ULONG value = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(RabidMemoryLimit), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaRabidSetMemoryLimit(NULL, value);
@@ -1189,13 +1060,10 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaRabidSetMacCacheSize)
     ULONG value = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(RabidMacCacheSize), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaRabidSetMacCacheSize(NULL, value);
@@ -1209,13 +1077,10 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaRabidSetDNSCacheSize)
     ULONG value = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(RabidDNSCacheSize), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaRabidSetDNSCacheSize(NULL, value);
@@ -1240,13 +1105,10 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCInit)
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvParentalControlRFCEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1266,7 +1128,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCInit)
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status1 = CosaStartAdvParentalControl(FALSE);
@@ -1275,7 +1136,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCInit)
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pAdvPC->bEnable);
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -startAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status2 = CosaAdvPCInit(NULL);
@@ -1314,13 +1174,10 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCDeInit)
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvParentalControlRFCEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     if ((file = fopen(fname, "r")))
@@ -1340,7 +1197,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCDeInit)
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -stopAdvPC &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status1 = CosaStopAdvParentalControl(FALSE);
@@ -1380,16 +1236,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvDFIcmpv6Init)
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintICMPv6Enabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableICMP6 &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvDFIcmpv6Init(NULL);
@@ -1413,16 +1265,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvDFIcmpv6DeInit)
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(DeviceFingerPrintICMPv6Enabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableICMP6 &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvDFIcmpv6DeInit(NULL);
@@ -1446,16 +1294,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaWSDisInit)
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(WSDiscoveryAnalysisEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableWSDiscovery &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaWSDisInit(NULL);
@@ -1479,16 +1323,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaWSDisDeInit)
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(WSDiscoveryAnalysisEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableWSDiscovery &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaWSDisDeInit(NULL);
@@ -1512,16 +1352,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecOTMInit)
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecOTMEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableOTM &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecOTMInit(NULL);
@@ -1545,16 +1381,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecOTMDeInit)
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecOTMEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableOTM &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecOTMDeInit(NULL);
@@ -1578,16 +1410,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecUserSpaceInit)
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecUserSpaceEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableUS &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecUserSpaceInit(NULL);
@@ -1612,16 +1440,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecUserSpaceDeInit)
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecUserSpaceEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableUS &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecUserSpaceDeInit(NULL);
@@ -1646,16 +1470,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentInit)
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecAgentEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableAGT &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecAgentInit(NULL);
@@ -1680,16 +1500,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentDeInit)
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecAgentEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableAGT &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecAgentDeInit(NULL);
@@ -1713,16 +1529,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSafeBrowsingInit)
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecSafeBrowsingEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableSBRule &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecSafeBrowsingInit(NULL);
@@ -1746,16 +1558,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSafeBrowsingDeInit)
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecSafeBrowsingEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableSBRule &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecSafeBrowsingDeInit(NULL);
@@ -1779,16 +1587,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryWiFiFPInit)
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTelemetryWiFiFPEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCTW &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecCujoTelemetryWiFiFPInit(NULL);
@@ -1812,16 +1616,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryWiFiFPDeInit)
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTelemetryWiFiFPEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCTW &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecCujoTelemetryWiFiFPDeInit(NULL);
@@ -1845,16 +1645,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTracerInit)
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTracerEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCT &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecCujoTracerInit(NULL);
@@ -1878,16 +1674,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTracerDeInit)
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTracerEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCT &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecCujoTracerDeInit(NULL);
@@ -1911,16 +1703,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryInit)
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTelemetryEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableCTD &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecCujoTelemetryInit(NULL);
@@ -1944,16 +1732,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryDeInit)
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTelemetryEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableCTD &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecCujoTelemetryDeInit(NULL);
@@ -1977,16 +1761,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentRaptrInit)
     g_pAdvSecAgent->pRaptr_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(RaptrEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -enableRaptr &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecAgentRaptrInit(NULL);
@@ -2010,16 +1790,12 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentRaptrDeInit)
     g_pAdvSecAgent->pRaptr_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(RaptrEnabled), _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableRaptr &"), _))
-        .Times(1)
         .WillOnce(Return(0));
 
     ANSC_STATUS status = CosaAdvSecAgentRaptrDeInit(NULL);

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityMock.h
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityMock.h
@@ -88,11 +88,8 @@ static async_id_t async_id[4];
 enum {SYS_EVENT_ERROR=-1, SYS_EVENT_OK, SYS_EVENT_TIMEOUT, SYS_EVENT_HANDLE_EXIT, SYS_EVENT_RECEIVED=0x10};
 
 /*
- * Common base test fixture shared by all CcspAdvSecurity test suites.
- * Centralizes mock object lifecycle (SetUp/TearDown) and provides helper
- * methods for agent data-model allocation and sentinel-file management,
- * eliminating the duplication that previously existed across the three
- * fixture classes.
+ * Common base test fixture shared by DML, Internal, and WebConfig test suites.
+ * Centralises mock object lifecycle to eliminate duplicated SetUp/TearDown code.
  */
 class CcspAdvSecurityTestBase : public ::testing::Test {
 protected:
@@ -150,53 +147,59 @@ protected:
         g_anscWrapperApiMock = nullptr;
     }
 
-    /* --- Agent data-model helpers --- */
+    /* --- Data model allocation helpers --- */
 
-    PCOSA_DATAMODEL_AGENT AllocateAgent() {
-        PCOSA_DATAMODEL_AGENT pAgent = (PCOSA_DATAMODEL_AGENT)malloc(sizeof(COSA_DATAMODEL_AGENT));
-        EXPECT_NE(pAgent, nullptr);
-        if (pAgent) {
-            memset(pAgent, 0, sizeof(COSA_DATAMODEL_AGENT));
-        }
-        return pAgent;
+    PCOSA_DATAMODEL_AGENT CreateAgent(BOOL bEnable = TRUE) {
+        PCOSA_DATAMODEL_AGENT p = (PCOSA_DATAMODEL_AGENT)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
+        EXPECT_NE(p, nullptr);
+        p->bEnable = bEnable;
+        g_pAdvSecAgent = p;
+        return p;
     }
 
-    void AllocateAgentWithAdvSec() {
-        g_pAdvSecAgent = AllocateAgent();
+    void CreateAdvSec() {
         ASSERT_NE(g_pAdvSecAgent, nullptr);
-        g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
+        g_pAdvSecAgent->pAdvSec = (PCOSA_DATAMODEL_ADVSEC)calloc(1, sizeof(COSA_DATAMODEL_ADVSEC));
         ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-        memset(g_pAdvSecAgent->pAdvSec, 0, sizeof(COSA_DATAMODEL_ADVSEC));
     }
 
-    void AllocateAgentWithSafeBrowsing() {
-        AllocateAgentWithAdvSec();
-        g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
+    void CreateSafeBrowsing(BOOL bEnable = FALSE) {
+        ASSERT_NE(g_pAdvSecAgent, nullptr);
+        if (!g_pAdvSecAgent->pAdvSec) CreateAdvSec();
+        g_pAdvSecAgent->pAdvSec->pSafeBrows = (PCOSA_DATAMODEL_SB)calloc(1, sizeof(COSA_DATAMODEL_SB));
         ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
-        memset(g_pAdvSecAgent->pAdvSec->pSafeBrows, 0, sizeof(COSA_DATAMODEL_SB));
+        g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = bEnable;
     }
 
-    void AllocateAgentWithSoftflowd() {
-        AllocateAgentWithAdvSec();
-        g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
+    void CreateSoftflowd(BOOL bEnable = FALSE) {
+        ASSERT_NE(g_pAdvSecAgent, nullptr);
+        if (!g_pAdvSecAgent->pAdvSec) CreateAdvSec();
+        g_pAdvSecAgent->pAdvSec->pSoftFlowd = (PCOSA_DATAMODEL_SOFTFLOWD)calloc(1, sizeof(COSA_DATAMODEL_SOFTFLOWD));
         ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-        memset(g_pAdvSecAgent->pAdvSec->pSoftFlowd, 0, sizeof(COSA_DATAMODEL_SOFTFLOWD));
+        g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = bEnable;
     }
 
-    void AllocateAgentWithAllFeatures() {
-        AllocateAgentWithAdvSec();
-        g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-        ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
-        memset(g_pAdvSecAgent->pAdvSec->pSafeBrows, 0, sizeof(COSA_DATAMODEL_SB));
-        g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-        ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-        memset(g_pAdvSecAgent->pAdvSec->pSoftFlowd, 0, sizeof(COSA_DATAMODEL_SOFTFLOWD));
-        g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
+    void CreateParentalControl(BOOL bEnable = FALSE) {
+        ASSERT_NE(g_pAdvSecAgent, nullptr);
+        g_pAdvSecAgent->pAdvPC = (PCOSA_DATAMODEL_ADVPARENTALCONTROL)calloc(1, sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
         ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-        memset(g_pAdvSecAgent->pAdvPC, 0, sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-        g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
+        g_pAdvSecAgent->pAdvPC->bEnable = bEnable;
+    }
+
+    void CreatePrivacyProtection(BOOL bEnable = FALSE) {
+        ASSERT_NE(g_pAdvSecAgent, nullptr);
+        g_pAdvSecAgent->pPrivProt = (PCOSA_DATAMODEL_PRIVACYPROTECTION)calloc(1, sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
         ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
-        memset(g_pAdvSecAgent->pPrivProt, 0, sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
+        g_pAdvSecAgent->pPrivProt->bEnable = bEnable;
+    }
+
+    void CreateRabid(ULONG memLimit = 0, ULONG macCache = 0, ULONG dnsCache = 0) {
+        ASSERT_NE(g_pAdvSecAgent, nullptr);
+        g_pAdvSecAgent->pRabid = (PCOSA_DATAMODEL_RABID)calloc(1, sizeof(COSA_DATAMODEL_RABID));
+        ASSERT_NE(g_pAdvSecAgent->pRabid, nullptr);
+        g_pAdvSecAgent->pRabid->uMemoryLimit = memLimit;
+        g_pAdvSecAgent->pRabid->uMacCacheSize = macCache;
+        g_pAdvSecAgent->pRabid->uDNSCacheSize = dnsCache;
     }
 
     void FreeAgent() {
@@ -221,6 +224,7 @@ protected:
         free(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC);
         free(g_pAdvSecAgent->pAdvSecCujoTracer_RFC);
         free(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC);
+        free(g_pAdvSecAgent->pLevl_RFC);
         free(g_pAdvSecAgent);
         g_pAdvSecAgent = nullptr;
     }
@@ -228,13 +232,13 @@ protected:
     /* --- Sentinel file helpers --- */
 
     void EnsureSentinelFile(const char *path) {
-        sentinelCreated_ = false;
-        FILE *file = fopen(path, "r");
-        if (file) {
-            fclose(file);
+        FILE *f = fopen(path, "r");
+        if (f) {
+            fclose(f);
+            sentinelCreated_ = false;
         } else {
-            file = fopen(path, "w");
-            if (file) fclose(file);
+            f = fopen(path, "w");
+            if (f) fclose(f);
             sentinelCreated_ = true;
         }
         sentinelPath_ = path;
@@ -248,20 +252,41 @@ protected:
         sentinelPath_.clear();
     }
 
-    /* --- Common mock expectation helpers --- */
+    /* --- Mock expectation helpers for common patterns --- */
 
-    void ExpectSyscfgSetAndCommit(const char *key) {
-        EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-            .WillOnce(Return(0));
+    void ExpectSyscfgSetAndCommit(const char *key, int times = 1) {
         EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(key), _))
-            .WillOnce(Return(0));
+            .Times(times)
+            .WillRepeatedly(Return(0));
         EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+            .Times(times)
+            .WillRepeatedly(Return(0));
+    }
+
+    void ExpectSprintfChk(int times = 1) {
+        EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+            .Times(times)
+            .WillRepeatedly(Return(0));
+    }
+
+    void ExpectScriptCall(const char *scriptSubstr) {
+        EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr(scriptSubstr), _))
+            .Times(1)
             .WillOnce(Return(0));
     }
 
-    void ExpectSecureSystemCall(const char *substring) {
-        EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr(substring), _))
-            .WillOnce(Return(0));
+    void ExpectStrcmpMatch(const char *expected, const char *param) {
+        int match = 0;
+        EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq(expected), strlen(expected), StrEq(param), _, _, _))
+            .Times(1)
+            .WillOnce(DoAll(SetArgPointee<3>(match), Return(EOK)));
+    }
+
+    void ExpectStrcmpMismatch(const char *expected, const char *param) {
+        int mismatch = 1;
+        EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq(expected), strlen(expected), StrEq(param), _, _, _))
+            .Times(1)
+            .WillOnce(DoAll(SetArgPointee<3>(mismatch), Return(EOK)));
     }
 
 private:

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityMock.h
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityMock.h
@@ -87,4 +87,186 @@ static async_id_t async_id[4];
 
 enum {SYS_EVENT_ERROR=-1, SYS_EVENT_OK, SYS_EVENT_TIMEOUT, SYS_EVENT_HANDLE_EXIT, SYS_EVENT_RECEIVED=0x10};
 
+/*
+ * Common base test fixture shared by all CcspAdvSecurity test suites.
+ * Centralizes mock object lifecycle (SetUp/TearDown) and provides helper
+ * methods for agent data-model allocation and sentinel-file management,
+ * eliminating the duplication that previously existed across the three
+ * fixture classes.
+ */
+class CcspAdvSecurityTestBase : public ::testing::Test {
+protected:
+    void SetUp() override {
+        g_syscfgMock = new SyscfgMock();
+        g_securewrapperMock = new SecureWrapperMock();
+        g_msgpackMock = new msgpackMock();
+        g_usertimeMock = new UserTimeMock();
+        g_safecLibMock = new SafecLibMock();
+        g_anscMemoryMock = new AnscMemoryMock();
+        g_baseapiMock = new BaseAPIMock();
+        g_traceMock = new TraceMock();
+        g_base64Mock = new base64Mock();
+        g_rbusMock = new rbusMock();
+        g_cmHALMock = new CmHalMock();
+        g_platformHALMock = new PlatformHalMock();
+        g_cjsonMock = new cjsonMock();
+        g_syseventMock = new SyseventMock();
+        g_webconfigFwMock = new webconfigFwMock();
+        g_anscWrapperApiMock = new AnscWrapperApiMock();
+    }
+
+    void TearDown() override {
+        delete g_syscfgMock;
+        delete g_securewrapperMock;
+        delete g_msgpackMock;
+        delete g_usertimeMock;
+        delete g_safecLibMock;
+        delete g_anscMemoryMock;
+        delete g_baseapiMock;
+        delete g_traceMock;
+        delete g_base64Mock;
+        delete g_rbusMock;
+        delete g_cmHALMock;
+        delete g_platformHALMock;
+        delete g_cjsonMock;
+        delete g_syseventMock;
+        delete g_webconfigFwMock;
+        delete g_anscWrapperApiMock;
+        g_syscfgMock = nullptr;
+        g_securewrapperMock = nullptr;
+        g_msgpackMock = nullptr;
+        g_usertimeMock = nullptr;
+        g_safecLibMock = nullptr;
+        g_anscMemoryMock = nullptr;
+        g_baseapiMock = nullptr;
+        g_traceMock = nullptr;
+        g_base64Mock = nullptr;
+        g_rbusMock = nullptr;
+        g_cmHALMock = nullptr;
+        g_platformHALMock = nullptr;
+        g_cjsonMock = nullptr;
+        g_syseventMock = nullptr;
+        g_webconfigFwMock = nullptr;
+        g_anscWrapperApiMock = nullptr;
+    }
+
+    /* --- Agent data-model helpers --- */
+
+    PCOSA_DATAMODEL_AGENT AllocateAgent() {
+        PCOSA_DATAMODEL_AGENT pAgent = (PCOSA_DATAMODEL_AGENT)malloc(sizeof(COSA_DATAMODEL_AGENT));
+        EXPECT_NE(pAgent, nullptr);
+        if (pAgent) {
+            memset(pAgent, 0, sizeof(COSA_DATAMODEL_AGENT));
+        }
+        return pAgent;
+    }
+
+    void AllocateAgentWithAdvSec() {
+        g_pAdvSecAgent = AllocateAgent();
+        ASSERT_NE(g_pAdvSecAgent, nullptr);
+        g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
+        ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
+        memset(g_pAdvSecAgent->pAdvSec, 0, sizeof(COSA_DATAMODEL_ADVSEC));
+    }
+
+    void AllocateAgentWithSafeBrowsing() {
+        AllocateAgentWithAdvSec();
+        g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
+        ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+        memset(g_pAdvSecAgent->pAdvSec->pSafeBrows, 0, sizeof(COSA_DATAMODEL_SB));
+    }
+
+    void AllocateAgentWithSoftflowd() {
+        AllocateAgentWithAdvSec();
+        g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
+        ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
+        memset(g_pAdvSecAgent->pAdvSec->pSoftFlowd, 0, sizeof(COSA_DATAMODEL_SOFTFLOWD));
+    }
+
+    void AllocateAgentWithAllFeatures() {
+        AllocateAgentWithAdvSec();
+        g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
+        ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+        memset(g_pAdvSecAgent->pAdvSec->pSafeBrows, 0, sizeof(COSA_DATAMODEL_SB));
+        g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
+        ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
+        memset(g_pAdvSecAgent->pAdvSec->pSoftFlowd, 0, sizeof(COSA_DATAMODEL_SOFTFLOWD));
+        g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
+        ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
+        memset(g_pAdvSecAgent->pAdvPC, 0, sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
+        g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
+        ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+        memset(g_pAdvSecAgent->pPrivProt, 0, sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
+    }
+
+    void FreeAgent() {
+        if (!g_pAdvSecAgent) return;
+        if (g_pAdvSecAgent->pAdvSec) {
+            free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
+            free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
+            free(g_pAdvSecAgent->pAdvSec);
+        }
+        free(g_pAdvSecAgent->pAdvPC);
+        free(g_pAdvSecAgent->pPrivProt);
+        free(g_pAdvSecAgent->pRabid);
+        free(g_pAdvSecAgent->pAdvPC_RFC);
+        free(g_pAdvSecAgent->pPrivProt_RFC);
+        free(g_pAdvSecAgent->pDFIcmpv6_RFC);
+        free(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC);
+        free(g_pAdvSecAgent->pAdvSecOTM_RFC);
+        free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
+        free(g_pAdvSecAgent->pRaptr_RFC);
+        free(g_pAdvSecAgent->pAdvSecAgent_RFC);
+        free(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC);
+        free(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC);
+        free(g_pAdvSecAgent->pAdvSecCujoTracer_RFC);
+        free(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC);
+        free(g_pAdvSecAgent);
+        g_pAdvSecAgent = nullptr;
+    }
+
+    /* --- Sentinel file helpers --- */
+
+    void EnsureSentinelFile(const char *path) {
+        sentinelCreated_ = false;
+        FILE *file = fopen(path, "r");
+        if (file) {
+            fclose(file);
+        } else {
+            file = fopen(path, "w");
+            if (file) fclose(file);
+            sentinelCreated_ = true;
+        }
+        sentinelPath_ = path;
+    }
+
+    void CleanupSentinelFile() {
+        if (sentinelCreated_ && !sentinelPath_.empty()) {
+            remove(sentinelPath_.c_str());
+        }
+        sentinelCreated_ = false;
+        sentinelPath_.clear();
+    }
+
+    /* --- Common mock expectation helpers --- */
+
+    void ExpectSyscfgSetAndCommit(const char *key) {
+        EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+            .WillOnce(Return(0));
+        EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(key), _))
+            .WillOnce(Return(0));
+        EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+            .WillOnce(Return(0));
+    }
+
+    void ExpectSecureSystemCall(const char *substring) {
+        EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr(substring), _))
+            .WillOnce(Return(0));
+    }
+
+private:
+    bool sentinelCreated_ = false;
+    std::string sentinelPath_;
+};
+
 #endif // CCSP_ADV_SECURITY_MOCK_H

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityWebconfigTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityWebconfigTest.cpp
@@ -18,61 +18,7 @@
 
 #include "CcspAdvSecurityMock.h"
 
-class CcspAdvSecurityWebconfigTestFixture : public ::testing::Test {
-protected:
-    void SetUp() override {
-       g_syscfgMock = new SyscfgMock();
-        g_securewrapperMock = new SecureWrapperMock();
-        g_msgpackMock = new msgpackMock();
-        g_usertimeMock = new UserTimeMock();
-        g_safecLibMock = new SafecLibMock();
-        g_anscMemoryMock = new AnscMemoryMock();
-        g_baseapiMock = new BaseAPIMock();
-        g_traceMock = new TraceMock();
-        g_base64Mock = new base64Mock();
-        g_rbusMock = new rbusMock();
-        g_cmHALMock = new CmHalMock();
-        g_platformHALMock = new PlatformHalMock();
-        g_cjsonMock = new cjsonMock();
-        g_syseventMock = new SyseventMock();
-        g_webconfigFwMock = new webconfigFwMock();
-        g_anscWrapperApiMock = new AnscWrapperApiMock();
-    }
-
-    void TearDown() override {
-        delete g_syscfgMock;
-        delete g_securewrapperMock;
-        delete g_msgpackMock;
-        delete g_usertimeMock;
-        delete g_safecLibMock;
-        delete g_anscMemoryMock;
-        delete g_baseapiMock;
-        delete g_traceMock;
-        delete g_base64Mock;
-        delete g_rbusMock;
-        delete g_cmHALMock;
-        delete g_platformHALMock;
-        delete g_cjsonMock;
-        delete g_syseventMock;
-        delete g_webconfigFwMock;
-        delete g_anscWrapperApiMock;
-        g_syscfgMock = nullptr;
-        g_securewrapperMock = nullptr;
-        g_msgpackMock = nullptr;
-        g_usertimeMock = nullptr;
-        g_safecLibMock = nullptr;
-        g_anscMemoryMock = nullptr;
-        g_baseapiMock = nullptr;
-        g_traceMock = nullptr;
-        g_base64Mock = nullptr;
-        g_rbusMock = nullptr;
-        g_cmHALMock = nullptr;
-        g_platformHALMock = nullptr;
-        g_cjsonMock = nullptr;
-        g_syseventMock = nullptr;
-        g_webconfigFwMock = nullptr;
-        g_anscWrapperApiMock = nullptr;
-    }
+class CcspAdvSecurityWebconfigTestFixture : public CcspAdvSecurityTestBase {
 };
 
 // cosa_adv_security_webconfig.c file test cases
@@ -82,7 +28,6 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_get_blobversion_suc
     char subdoc[] = "test";
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_get(_, _, _, _))
@@ -102,7 +47,6 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_get_blobversion_fai
     char subdoc[] = "test";
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_syscfgMock, syscfg_get(_, _, _, _))
         .WillOnce(DoAll(
@@ -126,11 +70,9 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_set_blobversion_suc
         .WillRepeatedly(Return(0));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(_, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
         .WillOnce(Return(0));
 
     int result = advsec_webconfig_set_blobversion(subdoc, version);
@@ -149,7 +91,6 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_set_blobversion_fai
         .WillRepeatedly(Return(0));
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(_, _))
-        .Times(1)
         .WillOnce(Return(1));
 
     int result = advsec_webconfig_set_blobversion(subdoc, version);
@@ -162,10 +103,8 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_init) {
     blobRegInfo *blobData;
 
     EXPECT_CALL(*g_safecLibMock, _memset_s_chk(_, _, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _strcpy_s_chk(_, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
 
     EXPECT_CALL(*g_webconfigFwMock, register_sub_docs(_, _, _, _))
@@ -211,13 +150,10 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_process_request_suc
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _memset_s_chk(_, _, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(_, _, _, _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -configure_features &"),_))
-        .Times(1)
         .WillOnce(Return(0));
 
     int result = advsec_webconfig_handle_blob(advsec.param);
@@ -269,13 +205,10 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_process_request_fai
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _memset_s_chk(_, _, _, _, _))
-        .Times(1)
         .WillOnce(Return(0));
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(_, _, _, _, _, _))
-        .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
     EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disable &"),_))
-        .Times(1)
         .WillOnce(Return(0));
     
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(_, _))


### PR DESCRIPTION
Resolves #72

## Summary
Refactors the Google Test test suite to reduce code duplication and improve maintainability.

### Changes
- **Extract `CcspAdvSecurityTestBase` base class** in `CcspAdvSecurityMock.h` with shared `SetUp()`/`TearDown()` managing all 16 mock objects, eliminating triplicated fixture code across 3 test files (~150 lines removed)
- **Add reusable helper methods** for common test patterns: `CreateAgent()`, `CreateAdvSec()`, `CreateSafeBrowsing()`, `CreateSoftflowd()`, `CreateParentalControl()`, `CreatePrivacyProtection()`, `CreateRabid()`, `FreeAgent()`, `EnsureSentinelFile()`, `CleanupSentinelFile()`, `ExpectSyscfgSetAndCommit()`, `ExpectSprintfChk()`, `ExpectScriptCall()`, `ExpectStrcmpMatch()`, `ExpectStrcmpMismatch()`
- **Fix inconsistent test naming**: remove `Check` prefix from DeviceFingerPrint test names
- **Standardize memory allocation**: replace `new`/`delete` with `calloc`/`free` for C struct allocation consistency