### PR TITLE
docs: Add FlushConntrackTable parameter to reference documentation

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -169,6 +169,7 @@ All follow the pattern: persist to syscfg → check DeviceFingerPrint active →
 | `CosaRabidSetMacCacheSize(value)` | Set Rabid MAC cache (max: 32768) |
 | `CosaRabidSetDNSCacheSize(value)` | Set Rabid DNS cache (max: 32768) |
 | `CosaAdvSecFetchSbConfig(param, ...)` | Fetch SafeBrowsing config from `/tmp/safebro.json` |
+| `CosaAdvSecFlushConntrackTable()` | Flush connection tracking table via `conntrack -F` |
 
 ## 6. Syscfg Utility APIs
 

--- a/docs/reference/feature-catalog.md
+++ b/docs/reference/feature-catalog.md
@@ -24,7 +24,7 @@ This catalog documents all security feature modules, their RFC toggle dependenci
 ### Identity
 
 - **TR-181**: `Device.DeviceInfo.X_RDKCENTRAL-COM_DeviceFingerPrint`
-- **Parameters**: `Enable` (bool), `LoggingPeriod` (uint), `EndpointURL` (string), `LogLevel` (uint)
+- **Parameters**: `Enable` (bool), `LoggingPeriod` (uint), `EndpointURL` (string), `LogLevel` (uint), `FlushConntrackTable` (bool, trigger)
 - **syscfg**: `Advsecurity_DeviceFingerPrint`
 - **Init/DeInit**: `CosaAdvSecInit()` / `CosaAdvSecDeInit()`
 - **Script**: `start_adv_security.sh -enable` / `-disable`

--- a/docs/reference/tr181-matrix.md
+++ b/docs/reference/tr181-matrix.md
@@ -18,6 +18,7 @@ This matrix maps all `Device.DeviceInfo.X_RDKCENTRAL-COM_*` ownership areas to i
 | `X_RDKCENTRAL-COM_DeviceFingerPrint.LoggingPeriod` | Telemetry logging interval (seconds) | `DeviceFingerPrint_SetParamUlongValue` | `CosaAdvSecSetLoggingPeriod()` | `Advsecurity_LoggingPeriod` | — |
 | `X_RDKCENTRAL-COM_DeviceFingerPrint.EndpointURL` | Cloud endpoint URL (HTTPS only) | `DeviceFingerPrint_SetParamStringValue` | URL validated by `isValidUrl()` | `Advsecurity_CustomEndpointURL` | — |
 | `X_RDKCENTRAL-COM_DeviceFingerPrint.LogLevel` | Agent log level | `DeviceFingerPrint_SetParamUlongValue` | `CosaAdvSecSetLogLevel()` | `Advsecurity_LogLevel` | — |
+| `X_RDKCENTRAL-COM_DeviceFingerPrint.FlushConntrackTable` | Trigger to flush connection tracking table (always reads FALSE) | `DeviceFingerPrint_SetParamBoolValue` | `CosaAdvSecFlushConntrackTable()` | — (trigger, no persistence) | — |
 
 ### AdvancedSecurity.SafeBrowsing Parameters
 


### PR DESCRIPTION
Updates reference documentation to include the new `FlushConntrackTable` TR-181 parameter added in PR #76.

### Files Updated
- **docs/reference/tr181-matrix.md**: Added FlushConntrackTable row to Core Feature Parameters table
- **docs/reference/api-reference.md**: Added CosaAdvSecFlushConntrackTable() to internal API table
- **docs/reference/feature-catalog.md**: Added FlushConntrackTable to DeviceFingerPrint parameters list

Relates to #75