### PR TITLE
feat: Add ismodulerestarted parameter to DeviceFingerPrint section

### DIFF
--- a/config/TR181-AdvSecurity.xml
+++ b/config/TR181-AdvSecurity.xml
@@ -66,6 +66,12 @@
                   <syntax>uint32</syntax>
                   <writable>true</writable>
                 </parameter>
+                <parameter>
+                  <name>ismodulerestarted</name>
+                  <type>boolean</type>
+                  <syntax>bool</syntax>
+                  <writable>false</writable>
+                </parameter>
               </parameters>
         </object>
         <object>

--- a/source/AdvSecurityDml/cosa_adv_security_dml.c
+++ b/source/AdvSecurityDml/cosa_adv_security_dml.c
@@ -141,6 +141,14 @@ DeviceFingerPrint_GetParamBoolValue
         return TRUE;
     }
 
+    rc = strcmp_s("ismodulerestarted", strlen("ismodulerestarted"), ParamName, &ind);
+    ERR_CHK(rc);
+    if((rc == EOK) && (!ind))
+    {
+        *pBool = CosaAdvSecIsAgentRestarted();
+        return TRUE;
+    }
+
     CcspTraceWarning(("%s: Unsupported parameter '%s'\n", __FUNCTION__, ParamName));
     return FALSE;
 }

--- a/source/AdvSecurityDml/cosa_adv_security_internal.c
+++ b/source/AdvSecurityDml/cosa_adv_security_internal.c
@@ -3521,3 +3521,109 @@ ANSC_STATUS CosaAdvSecAgentRaptrDeInit(ANSC_HANDLE hThisObject)
     CcspTraceWarning (("AdvSecAgentRaptr_RFCEnable:FALSE\n"));
     return returnStatus;
 }
+
+BOOL CosaAdvSecIsAgentRestarted(void)
+{
+    FILE *fp = NULL;
+    char pid_str[32] = {0};
+    char proc_path[64] = {0};
+    char stat_buf[512] = {0};
+    unsigned long long starttime = 0;
+    long uptime_sec = 0;
+    long agent_start_sec = 0;
+    long clk_tck = 0;
+    struct sysinfo si;
+    int i = 0;
+    char *token = NULL;
+
+    /* Read cujo-agent PID */
+    fp = fopen("/tmp/cujo-agent.pid", "r");
+    if (fp == NULL)
+    {
+        CcspTraceInfo(("%s: cujo-agent.pid not found, agent not running\n", __FUNCTION__));
+        return FALSE;
+    }
+    if (fgets(pid_str, sizeof(pid_str), fp) == NULL)
+    {
+        fclose(fp);
+        return FALSE;
+    }
+    fclose(fp);
+
+    /* Remove trailing newline */
+    pid_str[strcspn(pid_str, "\n")] = '\0';
+    if (pid_str[0] == '\0')
+    {
+        return FALSE;
+    }
+
+    /* Read /proc/<pid>/stat to get process start time */
+    snprintf(proc_path, sizeof(proc_path), "/proc/%s/stat", pid_str);
+    fp = fopen(proc_path, "r");
+    if (fp == NULL)
+    {
+        CcspTraceInfo(("%s: Cannot open %s, agent process not found\n", __FUNCTION__, proc_path));
+        return FALSE;
+    }
+    if (fgets(stat_buf, sizeof(stat_buf), fp) == NULL)
+    {
+        fclose(fp);
+        return FALSE;
+    }
+    fclose(fp);
+
+    /* Field 22 (1-indexed) in /proc/<pid>/stat is starttime in clock ticks.
+     * Skip past the comm field (enclosed in parentheses) first to avoid
+     * issues with spaces in the process name. */
+    token = strrchr(stat_buf, ')');
+    if (token == NULL)
+    {
+        return FALSE;
+    }
+    token++; /* move past ')' */
+
+    /* Now parse fields starting from field 3 (state). Field 22 is at index 20 from here. */
+    for (i = 0; i < 20 && token != NULL; i++)
+    {
+        token = strchr(token, ' ');
+        if (token != NULL)
+        {
+            token++;
+        }
+    }
+    if (token == NULL)
+    {
+        return FALSE;
+    }
+    starttime = strtoull(token, NULL, 10);
+    if (starttime == 0)
+    {
+        return FALSE;
+    }
+
+    /* Get system uptime */
+    if (sysinfo(&si) != 0)
+    {
+        CcspTraceError(("%s: sysinfo() failed\n", __FUNCTION__));
+        return FALSE;
+    }
+    uptime_sec = si.uptime;
+
+    /* Convert agent start time from clock ticks to seconds since boot */
+    clk_tck = sysconf(_SC_CLK_TCK);
+    if (clk_tck <= 0)
+    {
+        clk_tck = 100; /* default fallback */
+    }
+    agent_start_sec = (long)(starttime / (unsigned long long)clk_tck);
+
+    /* If agent started after boot (agent_start_sec > 0), it has been restarted */
+    if (agent_start_sec > 0)
+    {
+        CcspTraceInfo(("%s: Agent restarted. Agent start=%ld sec after boot, system uptime=%ld sec\n",
+                       __FUNCTION__, agent_start_sec, uptime_sec));
+        return TRUE;
+    }
+
+    return FALSE;
+}

--- a/source/AdvSecurityDml/cosa_adv_security_internal.h
+++ b/source/AdvSecurityDml/cosa_adv_security_internal.h
@@ -564,4 +564,10 @@ CosaAdvSecFetchSbConfig
         ULONG* pUlSize,
         ULONG* puLong
     );
+
+BOOL
+CosaAdvSecIsAgentRestarted
+    (
+        void
+    );
 #endif

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp
@@ -133,9 +133,37 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_U
         .Times(1)
         .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
 
+    EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("ismodulerestarted"), strlen("ismodulerestarted"), StrEq(ParamName), _, _, _))
+        .Times(1)
+        .WillOnce(DoAll(SetArgPointee<3>(comparisonResult), Return(EOK)));
+
     BOOL result = DeviceFingerPrint_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
 
     EXPECT_FALSE(result);
+
+    delete pMyObject;
+}
+
+TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_ismodulerestarted) {
+    BOOL resultBool;
+    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
+    g_pAdvSecAgent = pMyObject;
+
+    const char* ParamName = "ismodulerestarted";
+    int enableComparisonResult = 1;
+    int ismodulerestartedComparisonResult = 0;
+
+    EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
+        .Times(1)
+        .WillOnce(DoAll(SetArgPointee<3>(enableComparisonResult), Return(EOK)));
+
+    EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("ismodulerestarted"), strlen("ismodulerestarted"), StrEq(ParamName), _, _, _))
+        .Times(1)
+        .WillOnce(DoAll(SetArgPointee<3>(ismodulerestartedComparisonResult), Return(EOK)));
+
+    BOOL result = DeviceFingerPrint_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
+
+    EXPECT_TRUE(result);
 
     delete pMyObject;
 }


### PR DESCRIPTION
Resolves #66.

## Summary
Adds a new read-only boolean TR-181 parameter `ismodulerestarted` under `Device.DeviceInfo.X_RDKCENTRAL-COM_DeviceFingerPrint` that indicates whether the cujo-agent has been restarted since system boot.

## Implementation
- **`CosaAdvSecIsAgentRestarted()`** in `cosa_adv_security_internal.c`: Reads the cujo-agent PID from `/tmp/cujo-agent.pid`, then reads `/proc/<pid>/stat` to get the process start time (field 22, in clock ticks). Compares this with system uptime via `sysinfo()`. If the agent started after boot (start time > 0 seconds), it is considered restarted.
- **DML handler**: Added `ismodulerestarted` case in `DeviceFingerPrint_GetParamBoolValue` using the standard `strcmp_s` pattern.
- **TR-181 XML**: Added the parameter as a read-only boolean in `TR181-AdvSecurity.xml`.
- **Unit tests**: Added test cases for the new parameter in `CcspAdvSecurityDmlTest.cpp`.

## Files Changed
| File | Change |
|------|--------|
| `source/AdvSecurityDml/cosa_adv_security_internal.c` | Added `CosaAdvSecIsAgentRestarted()` function |
| `source/AdvSecurityDml/cosa_adv_security_internal.h` | Added function declaration |
| `source/AdvSecurityDml/cosa_adv_security_dml.c` | Added `ismodulerestarted` handling in GetParamBoolValue |
| `config/TR181-AdvSecurity.xml` | Added parameter definition |
| `source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp` | Added unit tests |

## Testing
- Parameter accessible via: `dmcli eRT getv Device.DeviceInfo.X_RDKCENTRAL-COM_DeviceFingerPrint.ismodulerestarted`
- Returns `true` if cujo-agent runtime < system uptime (agent restarted since boot)
- Returns `false` if agent has been running since boot or is not running