### PR TITLE
RDKB-65004: Refactor gtest testcases in source test application

### DIFF
--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityDmlTest.cpp
@@ -22,68 +22,13 @@ typedef void* ANSC_HANDLE;
 ANSC_HANDLE bus_handle = NULL;
 
 
-class CcspAdvSecurityDmlTestFixture : public ::testing::Test {
-protected:
-    void SetUp() override {
-        g_syscfgMock = new SyscfgMock();
-        g_securewrapperMock = new SecureWrapperMock();
-        g_msgpackMock = new msgpackMock();
-        g_usertimeMock = new UserTimeMock();
-        g_safecLibMock = new SafecLibMock();
-        g_anscMemoryMock = new AnscMemoryMock();
-        g_baseapiMock = new BaseAPIMock();
-        g_traceMock = new TraceMock();
-        g_base64Mock = new base64Mock();
-        g_rbusMock = new rbusMock();
-        g_cmHALMock = new CmHalMock();
-        g_platformHALMock = new PlatformHalMock();
-        g_cjsonMock = new cjsonMock();
-        g_syseventMock = new SyseventMock();
-        g_webconfigFwMock = new webconfigFwMock();
-        g_anscWrapperApiMock = new AnscWrapperApiMock();
-    }
-
-    void TearDown() override {
-        delete g_syscfgMock;
-        delete g_securewrapperMock;
-        delete g_msgpackMock;
-        delete g_usertimeMock;
-        delete g_safecLibMock;
-        delete g_anscMemoryMock;
-        delete g_baseapiMock;
-        delete g_traceMock;
-        delete g_base64Mock;
-        delete g_rbusMock;
-        delete g_cmHALMock;
-        delete g_platformHALMock;
-        delete g_cjsonMock;
-        delete g_syseventMock;
-        delete g_webconfigFwMock;
-        delete g_anscWrapperApiMock;
-        g_syscfgMock = nullptr;
-        g_securewrapperMock = nullptr;
-        g_msgpackMock = nullptr;
-        g_usertimeMock = nullptr;
-        g_safecLibMock = nullptr;
-        g_anscMemoryMock = nullptr;
-        g_baseapiMock = nullptr;
-        g_traceMock = nullptr;
-        g_base64Mock = nullptr;
-        g_rbusMock = nullptr;
-        g_cmHALMock = nullptr;
-        g_platformHALMock = nullptr;
-        g_cjsonMock = nullptr;
-        g_syseventMock = nullptr;
-        g_webconfigFwMock = nullptr;
-        g_anscWrapperApiMock = nullptr;
-    }
+class CcspAdvSecurityDmlTestFixture : public CcspAdvSecurityBaseFixture {
 };
 
 TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_Enable) {
     BOOL resultBool;
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
-    pMyObject->bEnable = TRUE;
-    g_pAdvSecAgent = pMyObject;
+    AllocateAdvSecAgent();
+    g_pAdvSecAgent->bEnable = TRUE;
 
     const char* ParamName = "Enable";
     int comparisonResult = 0;
@@ -97,14 +42,13 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_E
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    delete pMyObject;
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_Disable) {
     BOOL resultBool;
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
-    pMyObject->bEnable = FALSE;
-    g_pAdvSecAgent = pMyObject;
+    AllocateAdvSecAgent();
+    g_pAdvSecAgent->bEnable = FALSE;
 
     const char* ParamName = "Enable";
     int comparisonResult = 0;
@@ -118,13 +62,12 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_D
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    delete pMyObject;
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_UnsupportedParam) {
     BOOL resultBool;
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
-    g_pAdvSecAgent = pMyObject;
+    AllocateAdvSecAgent();
 
     const char* ParamName = "UnsupportedParam";
     int comparisonResult = 1;
@@ -137,15 +80,14 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamBoolValue_U
 
     EXPECT_FALSE(result);
 
-    delete pMyObject;
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_Enable) {
 
     const char *DeviceFingerPrintEnabled = "Advsecurity_DeviceFingerPrint";
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
-    pMyObject->bEnable = FALSE;
-    g_pAdvSecAgent = pMyObject;
+    AllocateAdvSecAgent();
+    g_pAdvSecAgent->bEnable = FALSE;
 
     const char* ParamName = "Enable";
     BOOL bValue = TRUE;
@@ -173,16 +115,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_E
     BOOL result = DeviceFingerPrint_SetParamBoolValue(NULL, (char*)ParamName, bValue);
 
     EXPECT_TRUE(result);
-    EXPECT_TRUE(pMyObject->bEnable);
+    EXPECT_TRUE(g_pAdvSecAgent->bEnable);
 
-    delete pMyObject;
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_Disable) {
     const char *DeviceFingerPrintEnabled = "Advsecurity_DeviceFingerPrint";
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
-    pMyObject->bEnable = TRUE;
-    g_pAdvSecAgent = pMyObject;
+    AllocateAdvSecAgent();
+    g_pAdvSecAgent->bEnable = TRUE;
 
     const char* ParamName = "Enable";
     BOOL bValue = FALSE;
@@ -210,16 +151,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamBoolValue_D
     BOOL result = DeviceFingerPrint_SetParamBoolValue(NULL, (char*)ParamName, bValue);
 
     EXPECT_TRUE(result);
-    EXPECT_FALSE(pMyObject->bEnable);
+    EXPECT_FALSE(g_pAdvSecAgent->bEnable);
 
-    delete pMyObject;
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamUlongValue_LoggingPeriod) {
     ULONG resultUlong;
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
-    pMyObject->ulLoggingPeriod = 100;
-    g_pAdvSecAgent = pMyObject;
+    AllocateAdvSecAgent();
+    g_pAdvSecAgent->ulLoggingPeriod = 100;
 
     const char* ParamName = "LoggingPeriod";
     int comparisonResult = 0;
@@ -233,13 +173,12 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamUlongValue_
     EXPECT_TRUE(result);
     EXPECT_EQ(100, resultUlong);
 
-    delete pMyObject;
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamUlongValue_LoggingPeriod) {
-    PCOSA_DATAMODEL_AGENT pMyObject = new COSA_DATAMODEL_AGENT;
-    pMyObject->ulLoggingPeriod = 100;
-    g_pAdvSecAgent = pMyObject;
+    AllocateAdvSecAgent();
+    g_pAdvSecAgent->ulLoggingPeriod = 100;
     const char *DeviceFingerPrintLogginPeriod = "Advsecurity_LoggingPeriod";
 
     const char* ParamName = "LoggingPeriod";
@@ -265,9 +204,9 @@ TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_SetParamUlongValue_
     BOOL result = DeviceFingerPrint_SetParamUlongValue(NULL, (char*)ParamName, bValue);
 
     EXPECT_TRUE(result);
-    EXPECT_EQ(200, pMyObject->ulLoggingPeriod);
+    EXPECT_EQ(200, g_pAdvSecAgent->ulLoggingPeriod);
 
-    delete pMyObject;
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, CheckDeviceFingerPrint_GetParamStringValue_EndpointURL) {
@@ -384,12 +323,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Enable) {
     const char* ParamName = "Enable";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = TRUE;
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
@@ -403,9 +337,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Enable) {
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Disable) {
@@ -413,12 +345,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Disable) {
     const char* ParamName = "Enable";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = TRUE;
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = FALSE;
@@ -432,9 +359,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamBoolValue_Disable) {
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Enable) {
@@ -446,14 +371,9 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Enable) {
     BOOL bValue = TRUE;
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
 
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
@@ -500,9 +420,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Enable) {
         }
     }
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Disable) {
@@ -514,14 +432,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Disable) {
     BOOL bValue = FALSE;
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
 
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = FALSE;
 
@@ -567,9 +479,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamBoolValue_Disable) {
         }
     }
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamUlongValue_LookupTimeout) {
@@ -577,13 +487,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamUlongValue_LookupTime
     const char* ParamName = "LookupTimeout";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
 
     g_pAdvSecAgent->pAdvSec->pSafeBrows->ulLookupTimeout = 100;
 
@@ -596,9 +501,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_GetParamUlongValue_LookupTime
     EXPECT_TRUE(result);
     EXPECT_EQ(100, resultUlong);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamUlongValue_LookupTimeout) {
@@ -607,13 +510,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamUlongValue_LookupTime
     int comparisonResult = 0;
     const char *AdvSecuritySBLookupTimeout = "Advsecurity_LookupTimeout";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
 
     g_pAdvSecAgent->pAdvSec->pSafeBrows->ulLookupTimeout = 100;
 
@@ -638,9 +536,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_SetParamUlongValue_LookupTime
     EXPECT_FALSE(result);
     EXPECT_EQ(100, bValue);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, SafeBrowsing_Validate) {
@@ -670,14 +566,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Enable) {
     const char* ParamName = "Enable";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
@@ -688,10 +578,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Enable) {
 
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
-
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Disable) {
@@ -699,14 +586,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Disable) {
     const char* ParamName = "Enable";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
@@ -717,10 +598,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_GetParamBoolValue_Disable) {
 
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
-
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Enable) {
@@ -732,15 +610,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Enable) {
     FILE* file = NULL;
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
@@ -786,10 +657,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Enable) {
             printf("Error deleting file %s", fname);
         }
     }
-
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -802,15 +670,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Disable) {
     FILE* file = NULL;
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Enable"), strlen("Enable"), StrEq(ParamName), _, _, _))
@@ -856,10 +717,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_SetParamBoolValue_Disable) {
             printf("Error deleting file %s", fname);
         }
     }
-
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, Softflowd_Validate) {
@@ -888,12 +746,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_
     const char* ParamName = "Activate";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
@@ -905,8 +759,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_Disable) {
@@ -914,12 +767,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_
     const char* ParamName = "Activate";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
@@ -931,8 +780,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_GetParamBoolValue_
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -945,12 +793,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
@@ -996,8 +840,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_
         }
     }
 
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_Disable) {
@@ -1009,12 +852,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
@@ -1060,8 +899,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_SetParamBoolValue_
         }
     }
 
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_Validate) {
@@ -1090,13 +928,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Enable
     const char* ParamName = "Activate";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
-
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
@@ -1108,8 +941,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Enable
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Disable) {
@@ -1117,13 +949,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Disabl
     const char* ParamName = "Activate";
     int comparisonResult = 0;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
-
     g_pAdvSecAgent->pPrivProt->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
@@ -1135,8 +962,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_GetParamBoolValue_Disabl
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Enable) {
@@ -1148,12 +974,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Enable
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
@@ -1199,8 +1021,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Enable
         }
     }
 
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Disable) {
@@ -1212,12 +1033,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Disabl
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
     g_pAdvSecAgent->pPrivProt->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _strcmp_s_chk(StrEq("Activate"), strlen("Activate"), StrEq(ParamName), _, _, _))
@@ -1263,8 +1080,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_SetParamBoolValue_Disabl
         }
     }
 
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_Validate) {
@@ -1292,12 +1108,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_GetParamUlongValue_MemoryLi
     ULONG resultUlong;
     const char* ParamName = "MemoryLimit";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pRabid = (COSA_DATAMODEL_RABID *)malloc(sizeof(COSA_DATAMODEL_RABID));
-    ASSERT_NE(g_pAdvSecAgent->pRabid, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pRabid->uMemoryLimit = 100;
 
     BOOL result = RabidFramework_GetParamUlongValue(NULL, (char*)ParamName, &resultUlong);
@@ -1305,8 +1116,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_GetParamUlongValue_MemoryLi
     EXPECT_TRUE(result);
     EXPECT_EQ(100, resultUlong);
 
-    free(g_pAdvSecAgent->pRabid);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1314,12 +1124,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_GetParamUlongValue_MacCache
     ULONG resultUlong;
     const char* ParamName = "MacCacheSize";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pRabid = (COSA_DATAMODEL_RABID *)malloc(sizeof(COSA_DATAMODEL_RABID));
-    ASSERT_NE(g_pAdvSecAgent->pRabid, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pRabid->uMacCacheSize = 100;
 
     BOOL result = RabidFramework_GetParamUlongValue(NULL, (char*)ParamName, &resultUlong);
@@ -1327,20 +1132,14 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_GetParamUlongValue_MacCache
     EXPECT_TRUE(result);
     EXPECT_EQ(100, resultUlong);
 
-    free(g_pAdvSecAgent->pRabid);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_GetParamUlongValue_DNSCacheSize) {
     ULONG resultUlong;
     const char* ParamName = "DNSCacheSize";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pRabid = (COSA_DATAMODEL_RABID *)malloc(sizeof(COSA_DATAMODEL_RABID));
-    ASSERT_NE(g_pAdvSecAgent->pRabid, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pRabid->uDNSCacheSize = 100;
 
     BOOL result = RabidFramework_GetParamUlongValue(NULL, (char*)ParamName, &resultUlong);
@@ -1348,8 +1147,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_GetParamUlongValue_DNSCache
     EXPECT_TRUE(result);
     EXPECT_EQ(100, resultUlong);
 
-    free(g_pAdvSecAgent->pRabid);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1359,12 +1157,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MemoryLi
     int comparisonResult = 0;
     const char *AdvSecurityRabidMemoryLimit = "Advsecurity_RabidMemoryLimit";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pRabid = (COSA_DATAMODEL_RABID *)malloc(sizeof(COSA_DATAMODEL_RABID));
-    ASSERT_NE(g_pAdvSecAgent->pRabid, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pRabid->uMemoryLimit = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1384,8 +1177,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MemoryLi
     EXPECT_TRUE(result);
     EXPECT_EQ(100, bValue);
 
-    free(g_pAdvSecAgent->pRabid);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MacCacheSize) {
@@ -1394,12 +1186,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MacCache
     int comparisonResult = 0;
     const char *AdvSecurityRabidMacCacheSize = "Advsecurity_RabidMacCacheSize";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pRabid = (COSA_DATAMODEL_RABID *)malloc(sizeof(COSA_DATAMODEL_RABID));
-    ASSERT_NE(g_pAdvSecAgent->pRabid, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pRabid->uMacCacheSize = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1419,8 +1206,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_MacCache
     EXPECT_TRUE(result);
     EXPECT_EQ(100, bValue);
 
-    free(g_pAdvSecAgent->pRabid);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_DNSCacheSize) {
@@ -1429,12 +1215,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_DNSCache
     int comparisonResult = 0;
     const char *AdvSecurityRabidDNSCacheSize = "Advsecurity_RabidDNSCacheSize";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pRabid = (COSA_DATAMODEL_RABID *)malloc(sizeof(COSA_DATAMODEL_RABID));
-    ASSERT_NE(g_pAdvSecAgent->pRabid, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pRabid->uDNSCacheSize = 100;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1454,20 +1235,14 @@ TEST_F(CcspAdvSecurityDmlTestFixture, RabidFramework_SetParamUlongValue_DNSCache
     EXPECT_TRUE(result);
     EXPECT_EQ(100, bValue);
 
-    free(g_pAdvSecAgent->pRabid);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pAdvPC_RFC = (COSA_DATAMODEL_ADVPC_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVPC_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC_RFC, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = TRUE;
 
     BOOL result = AdvancedParentalControl_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1475,8 +1250,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_GetParamBoolVa
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvPC_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1484,12 +1258,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_GetParamBoolVa
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pAdvPC_RFC = (COSA_DATAMODEL_ADVPC_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVPC_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC_RFC, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = FALSE;
 
     BOOL result = AdvancedParentalControl_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1497,8 +1266,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_GetParamBoolVa
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvPC_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolValue_Enable) {
@@ -1509,12 +1277,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolVa
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvPC_RFC = (COSA_DATAMODEL_ADVPC_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVPC_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC_RFC, nullptr);
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCRFCEnabled), _))
@@ -1557,8 +1321,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolVa
         }
     }
 
-    free(g_pAdvSecAgent->pAdvPC_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolValue_Disable) {
@@ -1569,12 +1332,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolVa
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvPC_RFC = (COSA_DATAMODEL_ADVPC_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVPC_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC_RFC, nullptr);
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityAPCRFCEnabled), _))
@@ -1617,20 +1376,14 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedParentalControl_RFC_SetParamBoolVa
         }
     }
 
-    free(g_pAdvSecAgent->pAdvPC_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pPrivProt_RFC = (COSA_DATAMODEL_PRIVACYPROTECTION_RFC *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt_RFC, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pPrivProt_RFC->bEnable = TRUE;
 
     BOOL result = PrivacyProtection_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1638,20 +1391,14 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_RFC_GetParamBoolValue_En
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pPrivProt_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_RFC_GetParamBoolValue_Disable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pPrivProt_RFC = (COSA_DATAMODEL_PRIVACYPROTECTION_RFC *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt_RFC, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pPrivProt_RFC->bEnable = FALSE;
 
     BOOL result = PrivacyProtection_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1659,20 +1406,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_RFC_GetParamBoolValue_Di
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pPrivProt_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_RFC_SetParamBoolValue_Enable) {
     const char *ParamName = "Enable";
     BOOL bValue = TRUE;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pPrivProt_RFC = (COSA_DATAMODEL_PRIVACYPROTECTION_RFC *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt_RFC, nullptr);
-
     g_pAdvSecAgent->pPrivProt_RFC->bEnable = TRUE;
 
     BOOL result = PrivacyProtection_RFC_SetParamBoolValue(NULL, (char*)ParamName, bValue);
@@ -1680,20 +1422,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_RFC_SetParamBoolValue_En
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pPrivProt_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pPrivProt_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_RFC_SetParamBoolValue_Disable) {
     const char *ParamName = "Enable";
     BOOL bValue = FALSE;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pPrivProt_RFC = (COSA_DATAMODEL_PRIVACYPROTECTION_RFC *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt_RFC, nullptr);
-
     g_pAdvSecAgent->pPrivProt_RFC->bEnable = FALSE;
 
 
@@ -1702,20 +1439,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, PrivacyProtection_RFC_SetParamBoolValue_Di
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pPrivProt_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pPrivProt_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pDFIcmpv6_RFC = (COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC *)malloc(sizeof(COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pDFIcmpv6_RFC, nullptr);
-
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = TRUE;
 
     BOOL result = DeviceFingerPrintICMPv6_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1723,20 +1455,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_GetParamBoolVa
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pDFIcmpv6_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_GetParamBoolValue_Disable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pDFIcmpv6_RFC = (COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC *)malloc(sizeof(COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pDFIcmpv6_RFC, nullptr);
-
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = FALSE;
 
     BOOL result = DeviceFingerPrintICMPv6_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1744,8 +1471,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_GetParamBoolVa
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pDFIcmpv6_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolValue_Enable) {
@@ -1753,12 +1479,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolVa
     BOOL bValue = TRUE;
     const char *AdvSecurityDFICMPv6Enable = "Adv_DFICMPv6RFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pDFIcmpv6_RFC = (COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC *)malloc(sizeof(COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pDFIcmpv6_RFC, nullptr);
-
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1782,8 +1504,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolVa
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pDFIcmpv6_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1792,12 +1513,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolVa
     BOOL bValue = FALSE;
     const char *AdvSecurityDFICMPv6Enable = "Adv_DFICMPv6RFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pDFIcmpv6_RFC = (COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC *)malloc(sizeof(COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pDFIcmpv6_RFC, nullptr);
-
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1821,20 +1538,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, DeviceFingerPrintICMPv6_RFC_SetParamBoolVa
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pDFIcmpv6_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC = (COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC *)malloc(sizeof(COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC, nullptr);
-
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = TRUE;
 
     BOOL result = WS_Discovery_Analysis_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1842,8 +1554,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_GetParamBoolValu
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1851,12 +1562,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_GetParamBoolValu
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC = (COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC *)malloc(sizeof(COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC, nullptr);
-
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = FALSE;
 
     BOOL result = WS_Discovery_Analysis_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1864,8 +1571,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_GetParamBoolValu
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValue_Enable) {
@@ -1873,12 +1579,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValu
     BOOL bValue = TRUE;
     const char *AdvSecurityWSDisEnable = "Adv_WSDisAnaRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC = (COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC *)malloc(sizeof(COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC, nullptr);
-
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1902,8 +1604,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValu
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1912,12 +1613,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValu
     BOOL bValue = FALSE;
     const char *AdvSecurityWSDisEnable = "Adv_WSDisAnaRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC = (COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC *)malloc(sizeof(COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC, nullptr);
-
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1941,20 +1638,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, WS_Discovery_Analysis_RFC_SetParamBoolValu
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvSecOTM_RFC = (COSA_DATAMODEL_ADVSECOTM_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECOTM_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecOTM_RFC, nullptr);
-
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = TRUE;
 
     BOOL result = AdvancedSecurityOTM_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1962,8 +1654,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_GetParamBoolValue_
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecOTM_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1971,12 +1662,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_GetParamBoolValue_
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvSecOTM_RFC = (COSA_DATAMODEL_ADVSECOTM_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECOTM_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecOTM_RFC, nullptr);
-
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = FALSE;
 
     BOOL result = AdvancedSecurityOTM_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -1984,8 +1671,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_GetParamBoolValue_
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecOTM_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_Enable) {
@@ -1993,12 +1679,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_
     BOOL bValue = TRUE;
     const char *AdvSecurityOTMEnable = "Adv_AdvSecOTMRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvSecOTM_RFC = (COSA_DATAMODEL_ADVSECOTM_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECOTM_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecOTM_RFC, nullptr);
-
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2022,8 +1704,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecOTM_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_Disable) {
@@ -2031,12 +1712,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_
     BOOL bValue = FALSE;
     const char *AdvSecurityOTMEnable = "Adv_AdvSecOTMRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pAdvSecOTM_RFC = (COSA_DATAMODEL_ADVSECOTM_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECOTM_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecOTM_RFC, nullptr);
-
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2060,20 +1737,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvancedSecurityOTM_RFC_SetParamBoolValue_
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecOTM_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pRaptr_RFC = (COSA_DATAMODEL_RAPTR_RFC *)malloc(sizeof(COSA_DATAMODEL_RAPTR_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pRaptr_RFC, nullptr);
-
     g_pAdvSecAgent->pRaptr_RFC->bEnable = TRUE;
 
     BOOL result = AdvSecAgentRaptr_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2081,8 +1753,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_GetParamBoolValue_Ena
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pRaptr_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -2090,12 +1761,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_GetParamBoolValue_Dis
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pRaptr_RFC = (COSA_DATAMODEL_RAPTR_RFC *)malloc(sizeof(COSA_DATAMODEL_RAPTR_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pRaptr_RFC, nullptr);
-
     g_pAdvSecAgent->pRaptr_RFC->bEnable = FALSE;
 
     BOOL result = AdvSecAgentRaptr_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2103,8 +1770,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_GetParamBoolValue_Dis
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pRaptr_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_SetParamBoolValue_Enable) {
@@ -2112,12 +1778,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_SetParamBoolValue_Ena
     BOOL bValue = TRUE;
     const char *AdvSecurityRaptrEnable = "Adv_RaptrRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pRaptr_RFC = (COSA_DATAMODEL_RAPTR_RFC *)malloc(sizeof(COSA_DATAMODEL_RAPTR_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pRaptr_RFC, nullptr);
-
     g_pAdvSecAgent->pRaptr_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2141,8 +1803,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_SetParamBoolValue_Ena
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pRaptr_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pRaptr_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -2150,12 +1811,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_SetParamBoolValue_Dis
     const char *ParamName = "Enable";
     BOOL bValue = FALSE;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-    g_pAdvSecAgent->pRaptr_RFC = (COSA_DATAMODEL_RAPTR_RFC *)malloc(sizeof(COSA_DATAMODEL_RAPTR_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pRaptr_RFC, nullptr);
-
     g_pAdvSecAgent->pRaptr_RFC->bEnable = FALSE;
 
     BOOL result = AdvSecAgentRaptr_RFC_SetParamBoolValue(NULL, (char*)ParamName, bValue);
@@ -2163,8 +1820,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgentRaptr_RFC_SetParamBoolValue_Dis
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pRaptr_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pRaptr_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -2172,12 +1828,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_GetParamBoolV
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
     BOOL result = AdvanceSecurityUserSpace_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2185,20 +1836,14 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_GetParamBoolV
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_GetParamBoolValue_Disable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
 
     BOOL result = AdvanceSecurityUserSpace_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2206,8 +1851,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_GetParamBoolV
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_SetParamBoolValue_Enable) {
@@ -2215,16 +1859,10 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_SetParamBoolV
     BOOL bValue = TRUE;
     const char *AdvSecurityUserSpaceEnable = "Adv_AdvSecUserSpaceRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
-    g_pAdvSecAgent->pAdvWifiDataCollection_RFC = (COSA_DATAMODEL_ADVSECWIFIDATACOLLECTION_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECWIFIDATACOLLECTION_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvWifiDataCollection_RFC, nullptr);
     g_pAdvSecAgent->pAdvWifiDataCollection_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2248,66 +1886,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_SetParamBoolV
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent->pAdvWifiDataCollection_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
-/*
-TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityUserSpace_RFC_SetParamBoolValue_Disable) {
-    const char *ParamName = "Enable";
-    BOOL bValue = FALSE;
-    const char *AdvSecurityUserSpaceEnable = "Adv_AdvSecUserSpaceRFCEnable";
-
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
-
-    g_pAdvSecAgent->pAdvWifiDataCollection_RFC = (COSA_DATAMODEL_ADVSECWIFIDATACOLLECTION_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECWIFIDATACOLLECTION_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvWifiDataCollection_RFC, nullptr);
-    g_pAdvSecAgent->pAdvWifiDataCollection_RFC->bEnable = FALSE;
-
-    EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
-        .WillOnce(Return(0));
-    EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecurityUserSpaceEnable), _))
-        .Times(1)
-        .WillOnce(Return(0));
-    EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
-        .WillOnce(Return(0));
-
-    EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableUS &"), _))
-        .Times(1)
-        .WillOnce(Return(0));
-
-    EXPECT_EQ(ANSC_STATUS_SUCCESS, CosaAdvSecUserSpaceDeInit(NULL));
-
-    BOOL result = AdvanceSecurityUserSpace_RFC_SetParamBoolValue(NULL, (char*)ParamName, bValue);
-
-    EXPECT_TRUE(result);
-    EXPECT_FALSE(g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable);
-
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent->pAdvWifiDataCollection_RFC);
-    free(g_pAdvSecAgent);
-}
-*/
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pAdvSecAgent_RFC = (COSA_DATAMODEL_ADVSECAGENT_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECAGENT_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecAgent_RFC, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = TRUE;
 
     BOOL result = AdvSecAgent_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2315,8 +1902,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_GetParamBoolValue_Enable) 
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecAgent_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -2324,12 +1910,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_GetParamBoolValue_Disable)
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-
-    g_pAdvSecAgent->pAdvSecAgent_RFC = (COSA_DATAMODEL_ADVSECAGENT_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECAGENT_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecAgent_RFC, nullptr);
-
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = FALSE;
 
     BOOL result = AdvSecAgent_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2337,8 +1918,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_GetParamBoolValue_Disable)
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecAgent_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Enable) {
@@ -2346,12 +1926,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Enable) 
     BOOL bValue = TRUE;
     const char *AdvSecurityAgentEnable = "Adv_AdvSecAgentRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecAgent_RFC = (COSA_DATAMODEL_ADVSECAGENT_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECAGENT_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecAgent_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2375,8 +1951,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Enable) 
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecAgent_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -2385,12 +1960,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Disable)
     BOOL bValue = FALSE;
     const char *AdvSecurityAgentEnable = "Adv_AdvSecAgentRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecAgent_RFC = (COSA_DATAMODEL_ADVSECAGENT_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECAGENT_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecAgent_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2414,20 +1985,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecAgent_RFC_SetParamBoolValue_Disable)
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecAgent_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC = (COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = TRUE;
 
     BOOL result = AdvSecSafeBrowsing_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2435,20 +2001,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_GetParamBoolValue_E
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_GetParamBoolValue_Disable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC = (COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = FALSE;
 
     BOOL result = AdvSecSafeBrowsing_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2456,8 +2017,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_GetParamBoolValue_D
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_Enable) {
@@ -2465,16 +2025,10 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_E
     BOOL bValue = TRUE;
     const char *AdvSecuritySafeBrowsingEnable = "Adv_AdvSecSafeBrowsingRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC = (COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = TRUE;
 
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2498,9 +2052,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_E
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC);
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_Disable) {
@@ -2508,16 +2060,10 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_D
     BOOL bValue = FALSE;
     const char *AdvSecuritySafeBrowsingEnable = "Adv_AdvSecSafeBrowsingRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC = (COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = FALSE;
 
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2541,21 +2087,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecSafeBrowsing_RFC_SetParamBoolValue_D
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC);
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = TRUE;
 
     BOOL result = AdvSecCujoTelemetryWiFiFP_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2563,20 +2103,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_GetParamBool
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_GetParamBoolValue_Disable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = FALSE;
 
     BOOL result = AdvSecCujoTelemetryWiFiFP_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2584,8 +2119,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_GetParamBool
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBoolValue_Enable) {
@@ -2593,16 +2127,10 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBool
     BOOL bValue = TRUE;
     const char *AdvSecurityCujoTelemetryWiFiFPEnable = "Adv_AdvSecCujoTelemetryWiFiFPRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = TRUE;
 
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2626,9 +2154,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBool
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC);
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBoolValue_Disable) {
@@ -2636,16 +2162,10 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBool
     BOOL bValue = FALSE;
     const char *AdvSecurityCujoTelemetryWiFiFPEnable = "Adv_AdvSecCujoTelemetryWiFiFPRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = FALSE;
 
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2669,21 +2189,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvSecCujoTelemetryWiFiFP_RFC_SetParamBool
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC);
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTracer_RFC = (COSA_DATAMODEL_ADVSECCUJOTRACER_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTRACER_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTracer_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = TRUE;
 
     BOOL result = AdvanceSecurityCujoTracer_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2691,20 +2205,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_GetParamBool
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTracer_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_GetParamBoolValue_Disable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTracer_RFC = (COSA_DATAMODEL_ADVSECCUJOTRACER_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTRACER_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTracer_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = FALSE;
 
     BOOL result = AdvanceSecurityCujoTracer_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2712,8 +2221,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_GetParamBool
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTracer_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBoolValue_Enable) {
@@ -2721,12 +2229,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBool
     BOOL bValue = TRUE;
     const char *AdvSecurityCujoTracerEnable = "Adv_AdvSecCujoTracerRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTracer_RFC = (COSA_DATAMODEL_ADVSECCUJOTRACER_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTRACER_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTracer_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2750,8 +2254,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBool
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTracer_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -2760,12 +2263,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBool
     BOOL bValue = FALSE;
     const char *AdvSecurityCujoTracerEnable = "Adv_AdvSecCujoTracerRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTracer_RFC = (COSA_DATAMODEL_ADVSECCUJOTRACER_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTRACER_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTracer_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2789,20 +2288,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTracer_RFC_SetParamBool
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTracer_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_GetParamBoolValue_Enable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = TRUE;
 
     BOOL result = AdvanceSecurityCujoTelemetry_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2810,20 +2304,15 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_GetParamB
     EXPECT_TRUE(result);
     EXPECT_TRUE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_GetParamBoolValue_Disable) {
     BOOL resultBool;
     const char* ParamName = "Enable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = FALSE;
 
     BOOL result = AdvanceSecurityCujoTelemetry_RFC_GetParamBoolValue(NULL, (char*)ParamName, &resultBool);
@@ -2831,8 +2320,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_GetParamB
     EXPECT_TRUE(result);
     EXPECT_FALSE(resultBool);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamBoolValue_Enable) {
@@ -2840,12 +2328,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamB
     BOOL bValue = TRUE;
     const char *AdvSecurityCujoTelemetryEnable = "Adv_AdvSecCujoTelemetryRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2869,8 +2353,7 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamB
     EXPECT_TRUE(result);
     EXPECT_TRUE(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -2879,12 +2362,8 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamB
     BOOL bValue = FALSE;
     const char *AdvSecurityCujoTelemetryEnable = "Adv_AdvSecCujoTelemetryRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
-
-    g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC, nullptr);
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -2908,6 +2387,5 @@ TEST_F(CcspAdvSecurityDmlTestFixture, AdvanceSecurityCujoTelemetry_RFC_SetParamB
     EXPECT_TRUE(result);
     EXPECT_FALSE(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityInternalTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityInternalTest.cpp
@@ -18,62 +18,7 @@
 
 #include "CcspAdvSecurityMock.h"
 
-class CcspAdvSecurityInternalTestFixture : public ::testing::Test {
-protected:
-    void SetUp() override {
-
-       g_syscfgMock = new SyscfgMock();
-        g_securewrapperMock = new SecureWrapperMock();
-        g_msgpackMock = new msgpackMock();
-        g_usertimeMock = new UserTimeMock();
-        g_safecLibMock = new SafecLibMock();
-        g_anscMemoryMock = new AnscMemoryMock();
-        g_baseapiMock = new BaseAPIMock();
-        g_traceMock = new TraceMock();
-        g_base64Mock = new base64Mock();
-        g_rbusMock = new rbusMock();
-        g_cmHALMock = new CmHalMock();
-        g_platformHALMock = new PlatformHalMock();
-        g_cjsonMock = new cjsonMock();
-        g_syseventMock = new SyseventMock();
-        g_webconfigFwMock = new webconfigFwMock();
-        g_anscWrapperApiMock = new AnscWrapperApiMock();
-    }
-
-    void TearDown() override {
-        delete g_syscfgMock;
-        delete g_securewrapperMock;
-        delete g_msgpackMock;
-        delete g_usertimeMock;
-        delete g_safecLibMock;
-        delete g_anscMemoryMock;
-        delete g_baseapiMock;
-        delete g_traceMock;
-        delete g_base64Mock;
-        delete g_rbusMock;
-        delete g_cmHALMock;
-        delete g_platformHALMock;
-        delete g_cjsonMock;
-        delete g_syseventMock;
-        delete g_webconfigFwMock;
-        delete g_anscWrapperApiMock;
-        g_syscfgMock = nullptr;
-        g_securewrapperMock = nullptr;
-        g_msgpackMock = nullptr;
-        g_usertimeMock = nullptr;
-        g_safecLibMock = nullptr;
-        g_anscMemoryMock = nullptr;
-        g_baseapiMock = nullptr;
-        g_traceMock = nullptr;
-        g_base64Mock = nullptr;
-        g_rbusMock = nullptr;
-        g_cmHALMock = nullptr;
-        g_platformHALMock = nullptr;
-        g_cjsonMock = nullptr;
-        g_syseventMock = nullptr;
-        g_webconfigFwMock = nullptr;
-        g_anscWrapperApiMock = nullptr;
-    }
+class CcspAdvSecurityInternalTestFixture : public CcspAdvSecurityBaseFixture {
 };
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb) {
@@ -83,12 +28,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb) {
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = FALSE;
     g_pAdvSecAgent->bEnable = TRUE;
@@ -125,9 +65,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb) {
 
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sf) {
@@ -137,12 +75,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sf) {
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = FALSE;
     g_pAdvSecAgent->bEnable = TRUE;
@@ -179,9 +112,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sf) {
 
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
 
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb_sf) {
@@ -192,14 +123,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb_sf) {
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = FALSE;
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = FALSE;
@@ -244,10 +168,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_start_features_sb_sf) {
         }
     }
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sb) {
@@ -257,12 +178,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sb) {
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
     g_pAdvSecAgent->bEnable = TRUE;
@@ -305,21 +221,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sb) {
         }
     }
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sf) {
     const advsec_feature_type type = ADVSEC_SOFTFLOWD;
     const char *AdvSecuritySFEnabled = "Advsecurity_Softflowd";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = TRUE;
     g_pAdvSecAgent->bEnable = TRUE;
@@ -342,9 +251,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sf) {
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sb_sf) {
@@ -352,14 +259,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sb_sf) {
     const char *AdvSecuritySBEnabled = "Advsecurity_SafeBrowsing";
     const char *AdvSecuritySFEnabled = "Advsecurity_Softflowd";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
     g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable = TRUE;
@@ -387,19 +287,13 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_advsec_stop_features_sb_sf) {
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSec->pSoftFlowd->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, Cosa_AdvSec_Agent_Raptr_Init) {
     const char *RaptrEnabled = "Adv_RaptrRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pRaptr_RFC = (COSA_DATAMODEL_RAPTR_RFC *)malloc(sizeof(COSA_DATAMODEL_RAPTR_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pRaptr_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pRaptr_RFC->bEnable = TRUE;
 
@@ -421,17 +315,13 @@ TEST_F(CcspAdvSecurityInternalTestFixture, Cosa_AdvSec_Agent_Raptr_Init) {
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pRaptr_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pRaptr_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, Cosa_AdvSec_Agent_Raptr_DeInit) {
     const char *RaptrEnabled = "Adv_RaptrRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pRaptr_RFC = (COSA_DATAMODEL_RAPTR_RFC *)malloc(sizeof(COSA_DATAMODEL_RAPTR_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pRaptr_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pRaptr_RFC->bEnable = FALSE;
 
@@ -453,8 +343,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, Cosa_AdvSec_Agent_Raptr_DeInit) {
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pRaptr_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pRaptr_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_start_privacy_protection) {
@@ -464,10 +353,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_start_privacy_protection) {
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pPrivProt->bEnable = TRUE;
 
@@ -504,8 +390,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_start_privacy_protection) {
         }
     }
 
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_stop_privacy_protection) {
@@ -515,10 +400,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_stop_privacy_protection) {
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pPrivProt->bEnable = FALSE;
 
@@ -560,15 +442,13 @@ TEST_F(CcspAdvSecurityInternalTestFixture, ccsp_stop_privacy_protection) {
         }
     }
 
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecInit_Success)
 {
     const char *DeviceFingerPrintEnabled = "Advsecurity_DeviceFingerPrint";
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = TRUE;
 
@@ -590,14 +470,13 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecInit_Success)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(g_pAdvSecAgent->bEnable, TRUE);
 
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecDeInit_Success)
 {
     const char *DeviceFingerPrintEnabled = "Advsecurity_DeviceFingerPrint";
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = FALSE;
 
@@ -618,7 +497,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecDeInit_Success)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(g_pAdvSecAgent->bEnable, FALSE);
 
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaStartAdvParentalControl_Success)
@@ -628,10 +507,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaStartAdvParentalControl_Success)
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
@@ -673,8 +549,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaStartAdvParentalControl_Success)
         }
     }
 
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaStopAdvParentalControl_Success)
@@ -684,10 +559,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaStopAdvParentalControl_Success)
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
@@ -729,8 +601,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaStopAdvParentalControl_Success)
         }
     }
 
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_fingerprint_enable)
@@ -750,18 +621,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_fingerpr
     feature.parental_control_activate = false;
     feature.privacy_protection_activate = false;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = TRUE;
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
@@ -805,12 +665,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_fingerpr
         }
     }
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_fingerprint_disable)
@@ -831,18 +686,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_fingerpr
     feature.parental_control_activate = false;
     feature.privacy_protection_activate = false;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = TRUE;
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
@@ -886,12 +730,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_fingerpr
         }
     }
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_configure_feature)
@@ -912,18 +751,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_configur
     feature.parental_control_activate = false;
     feature.privacy_protection_activate = false;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = TRUE;
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
@@ -967,12 +795,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, advsec_webconfig_handle_blob_configur
         }
     }
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecGetLoggingPeriod)
@@ -1058,12 +881,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecGetLookupTimeout)
     const char *AdvSecurityLookupTimeout = "Advsecurity_LookupTimeout";
     const char LookupTimeout[] = "350";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    AllocateAdvSecAgent();
 
     EXPECT_CALL(*g_syscfgMock, syscfg_get(_, StrEq(AdvSecurityLookupTimeout), _, _))
         .WillOnce(DoAll(
@@ -1076,9 +894,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecGetLookupTimeout)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(g_pAdvSecAgent->pAdvSec->pSafeBrows->ulLookupTimeout, 3);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSetLookupTimeout)
@@ -1086,12 +902,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSetLookupTimeout)
     const char *AdvSecurityLookupTimeout = "Advsecurity_LookupTimeout";
     ULONG value = 3;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
 
@@ -1113,9 +924,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSetLookupTimeout)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(g_pAdvSecAgent->pAdvSec->pSafeBrows->ulLookupTimeout, value);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1231,12 +1040,9 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCInit)
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
 
-    g_pAdvSecAgent->pAdvPC_RFC = (COSA_DATAMODEL_ADVPC_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVPC_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC_RFC, nullptr);
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = TRUE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1259,9 +1065,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCInit)
         fclose(file);
         val = 1;
     }
-
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
 
     g_pAdvSecAgent->pAdvPC->bEnable = TRUE;
 
@@ -1292,9 +1095,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCInit)
         }
     }
 
-    free(g_pAdvSecAgent->pAdvPC_RFC);
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCDeInit)
@@ -1305,12 +1106,9 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCDeInit)
     int val = 0;
     FILE* file = NULL;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    AllocateAdvSecAgent();
     g_pAdvSecAgent->bEnable = TRUE;
 
-    g_pAdvSecAgent->pAdvPC_RFC = (COSA_DATAMODEL_ADVPC_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVPC_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC_RFC, nullptr);
     g_pAdvSecAgent->pAdvPC_RFC->bEnable = FALSE;
 
     EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
@@ -1333,9 +1131,6 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCDeInit)
         fclose(file);
         val = 1;
     }
-
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
 
     g_pAdvSecAgent->pAdvPC->bEnable = FALSE;
 
@@ -1363,19 +1158,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvPCDeInit)
         }
     }
 
-    free(g_pAdvSecAgent->pAdvPC_RFC);
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvDFIcmpv6Init)
 {
     const char *DeviceFingerPrintICMPv6Enabled = "Adv_DFICMPv6RFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pDFIcmpv6_RFC = (COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC *)malloc(sizeof(COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pDFIcmpv6_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = TRUE;
 
@@ -1397,18 +1187,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvDFIcmpv6Init)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pDFIcmpv6_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvDFIcmpv6DeInit)
 {
     const char *DeviceFingerPrintICMPv6Enabled = "Adv_DFICMPv6RFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pDFIcmpv6_RFC = (COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC *)malloc(sizeof(COSA_DATAMODEL_DEVICEFINGERPRINTICMPv6_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pDFIcmpv6_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = FALSE;
 
@@ -1430,18 +1216,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvDFIcmpv6DeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pDFIcmpv6_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaWSDisInit)
 {
     const char *WSDiscoveryAnalysisEnabled = "Adv_WSDisAnaRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC = (COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC *)malloc(sizeof(COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = TRUE;
 
@@ -1463,18 +1245,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaWSDisInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaWSDisDeInit)
 {
     const char *WSDiscoveryAnalysisEnabled = "Adv_WSDisAnaRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC = (COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC *)malloc(sizeof(COSA_DATAMODEL_WSDISCOVERYANALYSIS_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = FALSE;
 
@@ -1496,18 +1274,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaWSDisDeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecOTMInit)
 {
     const char *AdvSecOTMEnabled = "Adv_AdvSecOTMRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecOTM_RFC = (COSA_DATAMODEL_ADVSECOTM_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECOTM_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecOTM_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = TRUE;
 
@@ -1529,18 +1303,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecOTMInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecOTM_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecOTMDeInit)
 {
     const char *AdvSecOTMEnabled = "Adv_AdvSecOTMRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecOTM_RFC = (COSA_DATAMODEL_ADVSECOTM_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECOTM_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecOTM_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = FALSE;
 
@@ -1562,18 +1332,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecOTMDeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecOTM_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecUserSpaceInit)
 {
     const char *AdvSecUserSpaceEnabled = "Adv_AdvSecUserSpaceRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = TRUE;
 
@@ -1595,53 +1361,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecUserSpaceInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
-
-/*
-TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecUserSpaceDeInit)
-{
-    const char *AdvSecUserSpaceEnabled = "Adv_AdvSecUserSpaceRFCEnable";
-
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC = (COSA_DATAMODEL_ADVSECUSERSPACE_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECUSERSPACE_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecUserSpace_RFC, nullptr);
-
-    g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = FALSE;
-
-    EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
-        .Times(1)
-        .WillOnce(Return(0));
-    EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecUserSpaceEnabled), _))
-        .Times(1)
-        .WillOnce(Return(0));
-    EXPECT_CALL(*g_syscfgMock, syscfg_commit())
-        .Times(1)
-        .WillOnce(Return(0));
-    EXPECT_CALL(*g_securewrapperMock, v_secure_system(HasSubstr("/usr/ccsp/advsec/start_adv_security.sh -disableUS &"), _))
-        .Times(1)
-        .WillOnce(Return(0));
-
-    ANSC_STATUS status = CosaAdvSecUserSpaceDeInit(NULL);
-
-    EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
-    EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable);
-
-    free(g_pAdvSecAgent->pAdvSecUserSpace_RFC);
-    free(g_pAdvSecAgent);
-}
-*/
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentInit)
 {
     const char *AdvSecAgentEnabled = "Adv_AdvSecAgentRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecAgent_RFC = (COSA_DATAMODEL_ADVSECAGENT_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECAGENT_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecAgent_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = TRUE;
 
@@ -1663,8 +1390,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecAgent_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 
@@ -1672,10 +1398,7 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentDeInit)
 {
     const char *AdvSecAgentEnabled = "Adv_AdvSecAgentRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecAgent_RFC = (COSA_DATAMODEL_ADVSECAGENT_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECAGENT_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecAgent_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = FALSE;
 
@@ -1697,18 +1420,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentDeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecAgent_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSafeBrowsingInit)
 {
     const char *AdvSecSafeBrowsingEnabled = "Adv_AdvSecSafeBrowsingRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC = (COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = TRUE;
 
@@ -1730,18 +1449,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSafeBrowsingInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSafeBrowsingDeInit)
 {
     const char *AdvSecSafeBrowsingEnabled = "Adv_AdvSecSafeBrowsingRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC = (COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECSAFEBROWSING_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = FALSE;
 
@@ -1763,18 +1478,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecSafeBrowsingDeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryWiFiFPInit)
 {
     const char *AdvSecCujoTelemetryWiFiFPEnabled = "Adv_AdvSecCujoTelemetryWiFiFPRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = TRUE;
 
@@ -1796,18 +1507,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryWiFiFPInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryWiFiFPDeInit)
 {
     const char *AdvSecCujoTelemetryWiFiFPEnabled = "Adv_AdvSecCujoTelemetryWiFiFPRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRYWIFIFP_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = FALSE;
 
@@ -1829,18 +1536,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryWiFiFPDeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTracerInit)
 {
     const char *AdvSecCujoTracerEnabled = "Adv_AdvSecCujoTracerRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecCujoTracer_RFC = (COSA_DATAMODEL_ADVSECCUJOTRACER_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTRACER_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTracer_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = TRUE;
 
@@ -1862,18 +1565,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTracerInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTracer_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTracerDeInit)
 {
     const char *AdvSecCujoTracerEnabled = "Adv_AdvSecCujoTracerRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecCujoTracer_RFC = (COSA_DATAMODEL_ADVSECCUJOTRACER_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTRACER_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTracer_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = FALSE;
 
@@ -1895,18 +1594,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTracerDeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTracer_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryInit)
 {
     const char *AdvSecCujoTelemetryEnabled = "Adv_AdvSecCujoTelemetryRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = TRUE;
 
@@ -1928,18 +1623,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryDeInit)
 {
     const char *AdvSecCujoTelemetryEnabled = "Adv_AdvSecCujoTelemetryRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC = (COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC *)malloc(sizeof(COSA_DATAMODEL_ADVSECCUJOTELEMETRY_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = FALSE;
 
@@ -1961,18 +1652,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecCujoTelemetryDeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentRaptrInit)
 {
     const char *RaptrEnabled = "Adv_RaptrRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pRaptr_RFC = (COSA_DATAMODEL_RAPTR_RFC *)malloc(sizeof(COSA_DATAMODEL_RAPTR_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pRaptr_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pRaptr_RFC->bEnable = TRUE;
 
@@ -1994,18 +1681,14 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentRaptrInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(TRUE, g_pAdvSecAgent->pRaptr_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pRaptr_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }
 
 TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentRaptrDeInit)
 {
     const char *RaptrEnabled = "Adv_RaptrRFCEnable";
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pRaptr_RFC = (COSA_DATAMODEL_RAPTR_RFC *)malloc(sizeof(COSA_DATAMODEL_RAPTR_RFC));
-    ASSERT_NE(g_pAdvSecAgent->pRaptr_RFC, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->pRaptr_RFC->bEnable = FALSE;
 
@@ -2027,6 +1710,5 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentRaptrDeInit)
     EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
     EXPECT_EQ(FALSE, g_pAdvSecAgent->pRaptr_RFC->bEnable);
 
-    free(g_pAdvSecAgent->pRaptr_RFC);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
 }

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityMock.h
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityMock.h
@@ -87,4 +87,108 @@ static async_id_t async_id[4];
 
 enum {SYS_EVENT_ERROR=-1, SYS_EVENT_OK, SYS_EVENT_TIMEOUT, SYS_EVENT_HANDLE_EXIT, SYS_EVENT_RECEIVED=0x10};
 
+// Base test fixture with common SetUp/TearDown for all test classes
+class CcspAdvSecurityBaseFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        g_syscfgMock = new SyscfgMock();
+        g_securewrapperMock = new SecureWrapperMock();
+        g_msgpackMock = new msgpackMock();
+        g_usertimeMock = new UserTimeMock();
+        g_safecLibMock = new SafecLibMock();
+        g_anscMemoryMock = new AnscMemoryMock();
+        g_baseapiMock = new BaseAPIMock();
+        g_traceMock = new TraceMock();
+        g_base64Mock = new base64Mock();
+        g_rbusMock = new rbusMock();
+        g_cmHALMock = new CmHalMock();
+        g_platformHALMock = new PlatformHalMock();
+        g_cjsonMock = new cjsonMock();
+        g_syseventMock = new SyseventMock();
+        g_webconfigFwMock = new webconfigFwMock();
+        g_anscWrapperApiMock = new AnscWrapperApiMock();
+    }
+
+    void TearDown() override {
+        delete g_syscfgMock;
+        delete g_securewrapperMock;
+        delete g_msgpackMock;
+        delete g_usertimeMock;
+        delete g_safecLibMock;
+        delete g_anscMemoryMock;
+        delete g_baseapiMock;
+        delete g_traceMock;
+        delete g_base64Mock;
+        delete g_rbusMock;
+        delete g_cmHALMock;
+        delete g_platformHALMock;
+        delete g_cjsonMock;
+        delete g_syseventMock;
+        delete g_webconfigFwMock;
+        delete g_anscWrapperApiMock;
+        g_syscfgMock = nullptr;
+        g_securewrapperMock = nullptr;
+        g_msgpackMock = nullptr;
+        g_usertimeMock = nullptr;
+        g_safecLibMock = nullptr;
+        g_anscMemoryMock = nullptr;
+        g_baseapiMock = nullptr;
+        g_traceMock = nullptr;
+        g_base64Mock = nullptr;
+        g_rbusMock = nullptr;
+        g_cmHALMock = nullptr;
+        g_platformHALMock = nullptr;
+        g_cjsonMock = nullptr;
+        g_syseventMock = nullptr;
+        g_webconfigFwMock = nullptr;
+        g_anscWrapperApiMock = nullptr;
+    }
+};
+
+// Helper to allocate g_pAdvSecAgent with all sub-structures (zero-initialized)
+inline void AllocateAdvSecAgent() {
+    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)calloc(1, sizeof(COSA_DATAMODEL_AGENT));
+    ASSERT_NE(g_pAdvSecAgent, nullptr);
+    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)calloc(1, sizeof(COSA_DATAMODEL_ADVSEC));
+    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
+    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)calloc(1, sizeof(COSA_DATAMODEL_SOFTFLOWD));
+    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
+    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)calloc(1, sizeof(COSA_DATAMODEL_SB));
+    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
+    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)calloc(1, sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
+    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
+    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)calloc(1, sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
+    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+    g_pAdvSecAgent->pRabid = (COSA_DATAMODEL_RABID *)calloc(1, sizeof(COSA_DATAMODEL_RABID));
+    ASSERT_NE(g_pAdvSecAgent->pRabid, nullptr);
+}
+
+// Helper to deallocate g_pAdvSecAgent and all sub-structures
+inline void DeallocateAdvSecAgent() {
+    if (g_pAdvSecAgent) {
+        if (g_pAdvSecAgent->pAdvSec) {
+            free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
+            free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
+            free(g_pAdvSecAgent->pAdvSec);
+        }
+        free(g_pAdvSecAgent->pAdvPC);
+        free(g_pAdvSecAgent->pPrivProt);
+        free(g_pAdvSecAgent->pRabid);
+        free(g_pAdvSecAgent);
+        g_pAdvSecAgent = nullptr;
+    }
+}
+
+// Helper to create the advsec sentinel file
+inline void CreateSentinelFile() {
+    FILE *fp = fopen("/tmp/advsec_initialized", "w");
+    ASSERT_NE(fp, nullptr);
+    fclose(fp);
+}
+
+// Helper to remove the advsec sentinel file
+inline void RemoveSentinelFile() {
+    remove("/tmp/advsec_initialized");
+}
+
 #endif // CCSP_ADV_SECURITY_MOCK_H

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityWebconfigTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityWebconfigTest.cpp
@@ -18,61 +18,7 @@
 
 #include "CcspAdvSecurityMock.h"
 
-class CcspAdvSecurityWebconfigTestFixture : public ::testing::Test {
-protected:
-    void SetUp() override {
-       g_syscfgMock = new SyscfgMock();
-        g_securewrapperMock = new SecureWrapperMock();
-        g_msgpackMock = new msgpackMock();
-        g_usertimeMock = new UserTimeMock();
-        g_safecLibMock = new SafecLibMock();
-        g_anscMemoryMock = new AnscMemoryMock();
-        g_baseapiMock = new BaseAPIMock();
-        g_traceMock = new TraceMock();
-        g_base64Mock = new base64Mock();
-        g_rbusMock = new rbusMock();
-        g_cmHALMock = new CmHalMock();
-        g_platformHALMock = new PlatformHalMock();
-        g_cjsonMock = new cjsonMock();
-        g_syseventMock = new SyseventMock();
-        g_webconfigFwMock = new webconfigFwMock();
-        g_anscWrapperApiMock = new AnscWrapperApiMock();
-    }
-
-    void TearDown() override {
-        delete g_syscfgMock;
-        delete g_securewrapperMock;
-        delete g_msgpackMock;
-        delete g_usertimeMock;
-        delete g_safecLibMock;
-        delete g_anscMemoryMock;
-        delete g_baseapiMock;
-        delete g_traceMock;
-        delete g_base64Mock;
-        delete g_rbusMock;
-        delete g_cmHALMock;
-        delete g_platformHALMock;
-        delete g_cjsonMock;
-        delete g_syseventMock;
-        delete g_webconfigFwMock;
-        delete g_anscWrapperApiMock;
-        g_syscfgMock = nullptr;
-        g_securewrapperMock = nullptr;
-        g_msgpackMock = nullptr;
-        g_usertimeMock = nullptr;
-        g_safecLibMock = nullptr;
-        g_anscMemoryMock = nullptr;
-        g_baseapiMock = nullptr;
-        g_traceMock = nullptr;
-        g_base64Mock = nullptr;
-        g_rbusMock = nullptr;
-        g_cmHALMock = nullptr;
-        g_platformHALMock = nullptr;
-        g_cjsonMock = nullptr;
-        g_syseventMock = nullptr;
-        g_webconfigFwMock = nullptr;
-        g_anscWrapperApiMock = nullptr;
-    }
+class CcspAdvSecurityWebconfigTestFixture : public CcspAdvSecurityBaseFixture {
 };
 
 // cosa_adv_security_webconfig.c file test cases
@@ -191,18 +137,7 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_process_request_suc
 
     int comparisonResult = 1;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = TRUE;
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
@@ -226,12 +161,7 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_process_request_suc
     pErr result2 = advsec_webconfig_process_request(&advsec);
     EXPECT_EQ(result2->ErrorCode, SUBDOC_NOT_SUPPORTED);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
     free(advsec.subdoc_name);
 }
 
@@ -249,18 +179,7 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_process_request_fai
 
     int comparisonResult = 1;
 
-    g_pAdvSecAgent = (COSA_DATAMODEL_AGENT *)malloc(sizeof(COSA_DATAMODEL_AGENT));
-    ASSERT_NE(g_pAdvSecAgent, nullptr);
-    g_pAdvSecAgent->pAdvSec = (COSA_DATAMODEL_ADVSEC *)malloc(sizeof(COSA_DATAMODEL_ADVSEC));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSoftFlowd = (COSA_DATAMODEL_SOFTFLOWD *)malloc(sizeof(COSA_DATAMODEL_SOFTFLOWD));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSoftFlowd, nullptr);
-    g_pAdvSecAgent->pAdvSec->pSafeBrows = (COSA_DATAMODEL_SB *)malloc(sizeof(COSA_DATAMODEL_SB));
-    ASSERT_NE(g_pAdvSecAgent->pAdvSec->pSafeBrows, nullptr);
-    g_pAdvSecAgent->pAdvPC = (COSA_DATAMODEL_ADVPARENTALCONTROL *)malloc(sizeof(COSA_DATAMODEL_ADVPARENTALCONTROL));
-    ASSERT_NE(g_pAdvSecAgent->pAdvPC, nullptr);
-    g_pAdvSecAgent->pPrivProt = (COSA_DATAMODEL_PRIVACYPROTECTION *)malloc(sizeof(COSA_DATAMODEL_PRIVACYPROTECTION));
-    ASSERT_NE(g_pAdvSecAgent->pPrivProt, nullptr);
+    AllocateAdvSecAgent();
 
     g_pAdvSecAgent->bEnable = TRUE;
     g_pAdvSecAgent->pAdvSec->pSafeBrows->bEnable = TRUE;
@@ -294,12 +213,7 @@ TEST_F(CcspAdvSecurityWebconfigTestFixture, advsec_webconfig_process_request_fai
     pErr result2 = advsec_webconfig_process_request(&advsec);
     EXPECT_EQ(result2->ErrorCode, SUBDOC_NOT_SUPPORTED);
 
-    free(g_pAdvSecAgent->pAdvSec->pSafeBrows);
-    free(g_pAdvSecAgent->pAdvSec->pSoftFlowd);
-    free(g_pAdvSecAgent->pAdvSec);
-    free(g_pAdvSecAgent->pAdvPC);
-    free(g_pAdvSecAgent->pPrivProt);
-    free(g_pAdvSecAgent);
+    DeallocateAdvSecAgent();
     free(advsec.subdoc_name);
 }
 


### PR DESCRIPTION
## Summary
- extract a shared base fixture for all advanced security gtest fixtures
- replace repeated mock setup/teardown with inherited base fixture lifecycle
- add reusable helpers for adv security agent allocation/deallocation
- apply allocation/deallocation helpers across DML, internal, and webconfig tests
- standardize DeviceFingerPrint tests to C-style allocation via shared helpers
- remove dead commented-out testcase blocks

## Validation
- static review of refactored test coverage paths and helper usage consistency
- ensured no test assertion logic changes were introduced

## Jira
- RDKB-65004

## GitHub Issue
- Fixes #72