### PR TITLE
RDKB-64617 Set Default RFC values on Fully Deployed RFC Features

### DIFF
--- a/source/AdvSecurityDml/cosa_adv_security_internal.c
+++ b/source/AdvSecurityDml/cosa_adv_security_internal.c
@@ -1101,6 +1101,8 @@ CosaSecurityInitialize
 {
     UNREFERENCED_PARAMETER(hThisObject);
     ANSC_STATUS             returnStatus        = ANSC_STATUS_SUCCESS;
+    ANSC_STATUS             getCujoTracerRfcStatus    = ANSC_STATUS_FAILURE;
+    ANSC_STATUS             getCujoTelemetryRfcStatus = ANSC_STATUS_FAILURE;
     ULONG                   Value = 0;
     ULONG                   ValueSB = 0;
     ULONG                   ValueSF = 0;
@@ -1373,8 +1375,8 @@ CosaSecurityInitialize
     CosaGetSysCfgUlong(g_AdvSecAgentEnabled, &ValueASAGENT_RFC);
     CosaGetSysCfgUlong(g_AdvSecSafeBrowsingEnabled, &ValueASSAFEBROWSING_RFC);
     CosaGetSysCfgUlong(g_AdvSecCujoTelemetryWiFiFPEnabled, &ValueASCUJOTELEMETRYWIFIFP_RFC);
-    CosaGetSysCfgUlong(g_AdvSecCujoTracerEnabled, &ValueASCUJOTRACER_RFC);
-    CosaGetSysCfgUlong(g_AdvSecCujoTelemetryEnabled, &ValueASCUJOTELEMETRY_RFC);
+    getCujoTracerRfcStatus = CosaGetSysCfgUlong(g_AdvSecCujoTracerEnabled, &ValueASCUJOTRACER_RFC);
+    getCujoTelemetryRfcStatus = CosaGetSysCfgUlong(g_AdvSecCujoTelemetryEnabled, &ValueASCUJOTELEMETRY_RFC);
     CosaGetSysCfgUlong(g_AdvSecSATEEnabled, &ValueASSATE_RFC);
     CosaGetSysCfgUlong(g_AdvSecTCPTrackerFilterDevicesEnabled, &ValueASTCPTrackerFilterDevices_RFC);
     CosaGetSysCfgUlong(g_AdvSecDoHBlockingEnabled, &ValueASDoHBlocking_RFC);
@@ -1394,6 +1396,22 @@ CosaSecurityInitialize
     g_pAdvSecAgent->pDFIcmpv6_RFC->bEnable = ValueDFIcmpv6_RFC;
     g_pAdvSecAgent->pWSDiscoveryAnalysis_RFC->bEnable = ValueWSA_RFC;
     g_pAdvSecAgent->pAdvSecOTM_RFC->bEnable = ValueASOTM_RFC;
+    g_pAdvSecAgent->pAdvSecUserSpace_RFC->bEnable = ValueASUSERSPACE_RFC;
+
+    returnStatus = CosaAdvSecApplyRfcDefaultTrue(
+        g_AdvSecCujoTracerEnabled,
+        getCujoTracerRfcStatus,
+        ValueASCUJOTRACER_RFC,
+        &g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable,
+        "AdvSecCujoTracer_RFCEnable");
+
+    returnStatus = CosaAdvSecApplyRfcDefaultTrue(
+        g_AdvSecCujoTelemetryEnabled,
+        getCujoTelemetryRfcStatus,
+        ValueASCUJOTELEMETRY_RFC,
+        &g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable,
+        "AdvSecCujoTelemetry_RFCEnable");
+
     if (ValueASUSERSPACE_RFC == 0)
     {
         // Enable user-space feature
@@ -1468,8 +1486,6 @@ CosaSecurityInitialize
     g_pAdvSecAgent->pAdvSecAgent_RFC->bEnable = ValueASAGENT_RFC;
     g_pAdvSecAgent->pAdvSecSafeBrowsing_RFC->bEnable = ValueASSAFEBROWSING_RFC;
     g_pAdvSecAgent->pAdvSecCujoTelemetryWiFiFP_RFC->bEnable = ValueASCUJOTELEMETRYWIFIFP_RFC;
-    g_pAdvSecAgent->pAdvSecCujoTracer_RFC->bEnable = ValueASCUJOTRACER_RFC;
-    g_pAdvSecAgent->pAdvSecCujoTelemetry_RFC->bEnable = ValueASCUJOTELEMETRY_RFC;
     g_pAdvSecAgent->pAdvSecSATE_RFC->bEnable = ValueASSATE_RFC;
     g_pAdvSecAgent->pAdvSecTCPTrackerFilterDevices_RFC->bEnable = ValueASTCPTrackerFilterDevices_RFC;
     g_pAdvSecAgent->pAdvSecDoHBlocking_RFC->bEnable = ValueASDoHBlocking_RFC;
@@ -1588,6 +1604,34 @@ ANSC_STATUS CosaSetSysCfgUlong(char* setting, ULONG value)
         }
     }
 
+    return ret;
+}
+
+ANSC_STATUS
+CosaAdvSecApplyRfcDefaultTrue
+    (
+        char* setting,
+        ANSC_STATUS getStatus,
+        ULONG value,
+        BOOL* pEnable,
+        const char* featureLogName
+    )
+{
+    ANSC_STATUS ret = ANSC_STATUS_SUCCESS;
+
+    if ((getStatus != ANSC_STATUS_SUCCESS) || (value == 0))
+    {
+        ret = CosaSetSysCfgUlong(setting, 1);
+        if (ret != ANSC_STATUS_SUCCESS)
+        {
+            CcspTraceError(("%s: syscfg_set failure\n", __FUNCTION__));
+        }
+        *pEnable = TRUE;
+        CcspTraceInfo(("%s:TRUE\n", featureLogName));
+        return ret;
+    }
+
+    *pEnable = value;
     return ret;
 }
 

--- a/source/AdvSecurityDml/cosa_adv_security_internal.h
+++ b/source/AdvSecurityDml/cosa_adv_security_internal.h
@@ -330,6 +330,16 @@ CosaSetSysCfgUlong
         ULONG value
     );
 
+    ANSC_STATUS
+CosaAdvSecApplyRfcDefaultTrue
+    (
+        char* setting,
+        ANSC_STATUS getStatus,
+        ULONG value,
+        BOOL* pEnable,
+        const char* featureLogName
+    );
+
 ANSC_STATUS
 CosaAdvSecGetCustomURL
     (

--- a/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityInternalTest.cpp
+++ b/source/test/CcspAdvSecurityDmlTest/CcspAdvSecurityInternalTest.cpp
@@ -2057,3 +2057,78 @@ TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecAgentRaptrDeInit)
     free(g_pAdvSecAgent->pRaptr_RFC);
     free(g_pAdvSecAgent);
 }
+
+TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecApplyRfcDefaultTrue_GetFailure_DefaultsToTrue)
+{
+    const char *AdvSecCujoTracerEnabled = "Adv_AdvSecCujoTracerRFCEnable";
+    BOOL enable = FALSE;
+
+    EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
+        .WillOnce(Return(0));
+    EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTracerEnabled), _))
+        .Times(1)
+        .WillOnce(Return(0));
+    EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
+        .WillOnce(Return(0));
+
+    ANSC_STATUS status = CosaAdvSecApplyRfcDefaultTrue(
+        (char*)AdvSecCujoTracerEnabled,
+        ANSC_STATUS_FAILURE,
+        0,
+        &enable,
+        "AdvSecCujoTracer_RFCEnable");
+
+    EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
+    EXPECT_EQ(enable, TRUE);
+}
+
+TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecApplyRfcDefaultTrue_ZeroValue_DefaultsToTrue)
+{
+    const char *AdvSecCujoTelemetryEnabled = "Adv_AdvSecCujoTelemetryRFCEnable";
+    BOOL enable = FALSE;
+
+    EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(1)
+        .WillOnce(Return(0));
+    EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTelemetryEnabled), _))
+        .Times(1)
+        .WillOnce(Return(0));
+    EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(1)
+        .WillOnce(Return(0));
+
+    ANSC_STATUS status = CosaAdvSecApplyRfcDefaultTrue(
+        (char*)AdvSecCujoTelemetryEnabled,
+        ANSC_STATUS_SUCCESS,
+        0,
+        &enable,
+        "AdvSecCujoTelemetry_RFCEnable");
+
+    EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
+    EXPECT_EQ(enable, TRUE);
+}
+
+TEST_F(CcspAdvSecurityInternalTestFixture, CosaAdvSecApplyRfcDefaultTrue_EnabledValue_NoDefaultWrite)
+{
+    const char *AdvSecCujoTracerEnabled = "Adv_AdvSecCujoTracerRFCEnable";
+    BOOL enable = FALSE;
+
+    EXPECT_CALL(*g_syscfgMock, syscfg_set_nns(StrEq(AdvSecCujoTracerEnabled), _))
+        .Times(0);
+    EXPECT_CALL(*g_syscfgMock, syscfg_commit())
+        .Times(0);
+    EXPECT_CALL(*g_safecLibMock, _sprintf_s_chk(_, _, _, _))
+        .Times(0);
+
+    ANSC_STATUS status = CosaAdvSecApplyRfcDefaultTrue(
+        (char*)AdvSecCujoTracerEnabled,
+        ANSC_STATUS_SUCCESS,
+        1,
+        &enable,
+        "AdvSecCujoTracer_RFCEnable");
+
+    EXPECT_EQ(status, ANSC_STATUS_SUCCESS);
+    EXPECT_EQ(enable, TRUE);
+}


### PR DESCRIPTION
Reason for change: enable Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AdvanceSecurityCujoTelemetry.Enable & Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AdvanceSecurityCujoTracer.Enable to true

Test Procedure: Ensure default value persists on FR scenario's and no functionality issue observed.
Risks: Low
Signed-off-by: arunkumar_nagulapally@comcast.com