### PR TITLE
RDKB-64184, RDKB-63906 : Remove platform specific checks for network intelligence feature

### DIFF
--- a/scripts/advsec.sh
+++ b/scripts/advsec.sh
@@ -196,13 +196,6 @@ if [ "$MODEL_NUM" = "TG1682G" ] || [ "$MODEL_NUM" = "DPC3941" ] || [ "$MODEL_NUM
     export CC_PLATFORM_TYPE="PUMA"
 fi
 
-#NI check is added for XB8
-if [ "$MODEL_NUM" = "CGM4981COM" ]; then
-    export NI_SUPPORTED="true"
-else
-    export NI_SUPPORTED="false"
-fi
-
 advsec_is_agent_installed()
 {
     if [ -e ${RUNTIME_DIR}/bin/launch-${CUJO_AGENT} ]; then

--- a/scripts/start_adv_security.sh
+++ b/scripts/start_adv_security.sh
@@ -127,12 +127,10 @@ then
             disable_raptr
     fi
 
-    if [ "$NI_SUPPORTED" = "true" ]; then
-        if [ "$ADVSEC_NETWORKINTELLIGENCE_RFC_ENABLED" = "1" ]; then
-                enable_networkintelligence
-        else
-                disable_networkintelligence
-        fi
+    if [ "$ADVSEC_NETWORKINTELLIGENCE_RFC_ENABLED" = "1" ]; then
+        enable_networkintelligence
+    elif [ "$ADVSEC_NETWORKINTELLIGENCE_RFC_ENABLED" = "0" ]; then
+        disable_networkintelligence
     fi
 
     if [ "$ADVSEC_WIFIDATACOLLECTION_RFC_ENABLED" = "1" ]; then


### PR DESCRIPTION
Reason for change: Removed platform specific checks for network intelligence feature

Test Procedure:

    Cujo Agent process should work as designed.
    If Network Intelligence RFC is enabled, cujo-qosd process should work as designed.

Risks: Low
Priority: P1

Signed-off-by: Santhosh_GujulvaJagadeesh@comcast.com