### PR TITLE
RDKB-64184, RDKB-63906 : start or stop Network Intelligence (NI) service only if present

### DIFF
--- a/scripts/start_adv_security.sh
+++ b/scripts/start_adv_security.sh
@@ -129,7 +129,7 @@ then
 
     if [ "$ADVSEC_NETWORKINTELLIGENCE_RFC_ENABLED" = "1" ]; then
         enable_networkintelligence
-    elif [ "$ADVSEC_NETWORKINTELLIGENCE_RFC_ENABLED" = "0" ]; then
+    else
         disable_networkintelligence
     fi
 
@@ -638,7 +638,9 @@ enable_networkintelligence()
 {
     touch $ADVSEC_NETWORKINTELLIGENCE_ENABLED_PATH
     echo_t ${ADV_NETWORKINTELLIGENCE_RFC_ENABLE_LOG} >> ${ADVSEC_AGENT_LOG_PATH}
-    systemctl start cujo-ni
+    if systemctl list-unit-files cujo-ni.service | grep -q cujo-ni; then
+        systemctl start cujo-ni
+    fi
 
     if [ "$1" = "RR" ]; then
         advsec_restart_agent "AgentNetworkIntelligence_RFC_Enabled"
@@ -653,7 +655,9 @@ disable_networkintelligence()
 {
     rm -f $ADVSEC_NETWORKINTELLIGENCE_ENABLED_PATH
     echo_t ${ADV_NETWORKINTELLIGENCE_RFC_DISABLE_LOG} >> ${ADVSEC_AGENT_LOG_PATH}
-    systemctl stop cujo-ni
+    if systemctl list-unit-files cujo-ni.service | grep -q cujo-ni; then
+        systemctl stop cujo-ni
+    fi
 
     if [ "$1" = "RR" ]; then
         advsec_restart_agent "AgentNetworkIntelligence_RFC_Disabled"

--- a/scripts/start_adv_security.sh
+++ b/scripts/start_adv_security.sh
@@ -638,8 +638,8 @@ enable_networkintelligence()
 {
     touch $ADVSEC_NETWORKINTELLIGENCE_ENABLED_PATH
     echo_t ${ADV_NETWORKINTELLIGENCE_RFC_ENABLE_LOG} >> ${ADVSEC_AGENT_LOG_PATH}
-    if systemctl list-unit-files cujo-ni.service | grep -q cujo-ni; then
-        systemctl start cujo-ni
+    if systemctl list-unit-files cujo-ni.service 2>/dev/null | grep -q '^cujo-ni\.service'; then
+        systemctl start cujo-ni.service
     fi
 
     if [ "$1" = "RR" ]; then
@@ -655,8 +655,8 @@ disable_networkintelligence()
 {
     rm -f $ADVSEC_NETWORKINTELLIGENCE_ENABLED_PATH
     echo_t ${ADV_NETWORKINTELLIGENCE_RFC_DISABLE_LOG} >> ${ADVSEC_AGENT_LOG_PATH}
-    if systemctl list-unit-files cujo-ni.service | grep -q cujo-ni; then
-        systemctl stop cujo-ni
+    if systemctl list-unit-files cujo-ni.service 2>/dev/null | grep -q '^cujo-ni\.service'; then
+        systemctl stop cujo-ni.service
     fi
 
     if [ "$1" = "RR" ]; then


### PR DESCRIPTION
Reason for change: On NI RFC DML parameter enable or disable, start or stop NI service only if present.
Test Procedure:

    Cujo Agent process should work as designed.
    If Network Intelligence RFC is enabled, cujo-qosd process should work as designed.

Risks: Low
Priority: P1

Signed-off-by: Santhosh_GujulvaJagadeesh@comcast.com