### PR TITLE
RDKB-66162 : Rename Cujo PEM certificate

### DIFF
--- a/scripts/advsec.sh
+++ b/scripts/advsec.sh
@@ -88,7 +88,7 @@ export ADVSEC_CLOUD_IP=/tmp/advsec_cloud_ipv4
 export ADVSEC_CLOUD_HOST=/tmp/advsec_cloud_host
 export ADVSEC_ASSOC_SUCCESS=/tmp/advsec_assoc_success
 export ADVSEC_IPSETLIST_CREATED=/tmp/advsec_ipsetlist_created
-export ADVSEC_DEVICE_CERT=/tmp/cujo_xpki_cert.pem
+export ADVSEC_DEVICE_CERT=/tmp/cujo_cert.pem
 export ADV_PARENTAL_CONTROL_ACTIVEMACSFILE=/tmp/activemacs
 if [ "$BOX_TYPE" != "XB3" ] && [ "$BOX_TYPE" != "XF3" ]; then
 export ADVSEC_DF_ICMPv6_ENABLED_PATH=/tmp/advsec_df_icmpv6_enabled


### PR DESCRIPTION
Reason for change: To remove existing PEM certificate /tmp/cujo_cert.pem while restarting CcspAdvSecuritySsp

Test Procedure:
1) Run "/usr/ccsp/advsec/start_adv_security.sh -disable &"
2) Check if the file /tmp/cujo_cert.pem is absent

Risks: Low
Priority: P1

Signed-off-by: Santhosh_GujulvaJagadeesh@comcast.com